### PR TITLE
docs: README — HTTPS install fallback when SSH keys absent

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,18 @@ The plugin is **repo-agnostic**: it discovers worktree base, default branch, and
 /plugin marketplace add AhmedElBanna80/cmux-tab-agents
 ```
 
+The short form above clones over SSH. If you don't have a GitHub SSH key configured, the clone will fail — use the HTTPS URL instead:
+
+```sh
+/plugin marketplace add https://github.com/AhmedElBanna80/cmux-tab-agents
+```
+
+Or, if you want the short form to keep working everywhere, tell git to rewrite GitHub SSH URLs to HTTPS globally:
+
+```sh
+git config --global url."https://github.com/".insteadOf "git@github.com:"
+```
+
 ### 2. Install the plugin
 
 ```sh


### PR DESCRIPTION
## Summary

Adds an HTTPS install fallback to the README "Install" section. The short `/plugin marketplace add owner/repo` form clones over SSH, which fails for users without GitHub SSH keys configured. Readers now have two documented escape hatches: the explicit HTTPS URL form, and a global `git config url.insteadOf` rewrite for keeping the short form working.

Closes #2.

## Test plan

- [x] `git diff` reviewed: README.md only, +12 lines.
- [x] No code changes — docs-only.

## Dispatch trail

Dispatched via the `cmux-tab-agents` skill itself. Implementer in `surface:17`, worktree at `~/alpheya/repos/worktrees/cmux-tab-agents/issue-2/cmux-tab-agents`. Spec/code reviewers skipped — trivial docs-only change, 1 file, +12 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)