### PR TITLE
feat: v0.3.0 — configurable model/effort defaults + /cmux-tab-agents:setup

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "cmux-tab-agents",
       "description": "Claude Code subagent dispatcher for cmux: spawn the implementer/spec-reviewer/code-reviewer pipeline as real claude processes in cmux tabs, each in its own git worktree.",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "source": "./",
       "author": {
         "name": "Ahmed El Banna",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cmux-tab-agents",
   "description": "Claude Code subagent dispatcher for cmux: spawn the implementer/spec-reviewer/code-reviewer pipeline as real claude processes in cmux tabs, each in its own git worktree. Forks superpowers:subagent-driven-development with TDD discipline, verification iron law, and a hard prohibition on git --no-verify and other hook bypasses baked into every spawned tab-agent.",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "author": {
     "name": "Ahmed El Banna",
     "email": "ahmed.henidy@alpheya.com"

--- a/commands/setup.md
+++ b/commands/setup.md
@@ -1,0 +1,115 @@
+---
+description: Interactive setup wizard for cmux-tab-agents — pick default model, effort, and worktree config in one go
+---
+
+# cmux-tab-agents setup
+
+You are running the interactive setup wizard for the **cmux-tab-agents** plugin. Your job is to ask the user a small number of questions, then write a single TOML config file. After this command runs once, every dispatch (`dispatch-implementer.sh`, `dispatch-spec-reviewer.sh`, `dispatch-code-reviewer.sh`) will pick up these defaults automatically — the planner won't have to repeat `--model` / `--effort` on every call.
+
+## Step 0 — Greet (one short paragraph)
+
+Tell the user, in 2–3 sentences:
+
+- This wizard configures defaults for the implementer / spec-reviewer / code-reviewer tabs that the plugin spawns.
+- It's purely additive: anything you skip here will fall back to the user's `claude` defaults at dispatch time.
+- It writes one file (TOML). Resolution order at dispatch time is documented; you'll show it at the end.
+
+Do not dump the full resolution table now — show it once at the very end, after the file is written.
+
+## Step 1 — Default model
+
+Use **AskUserQuestion** with `multiSelect: false`, header "Model", question "Default model for tab-agents?" and these options:
+
+- `claude-sonnet-4-6` — recommended for parallel mechanical work (refactors, codemods, wiring tests).
+- `claude-opus-4-7` — recommended for complex reasoning, design work, ambiguous specs.
+- `claude-haiku-4-5-20251001` — fastest / cheapest. Trivial tasks only.
+- `Skip` — let each dispatch decide via its own `--model` flag, env var, or the `claude` CLI default.
+
+Save the user's choice as `MODEL_CHOICE`. If they picked `Skip`, leave it unset.
+
+## Step 2 — Default effort
+
+Use **AskUserQuestion** with `multiSelect: false`, header "Effort", question "Default thinking-effort level?" and these options:
+
+- `low` — fastest, cheapest. For mechanical edits where the path is obvious.
+- `medium` — balanced. Sensible default for most tasks.
+- `high` — more reasoning steps. For tasks with non-trivial design work.
+- `xhigh` — extensive reasoning. For ambiguous specs or tricky bugs.
+- `max` — maximum reasoning. Reserve for the hardest cases; expect significant cost.
+- `Skip` — let each dispatch decide via its own `--effort` flag, env var, or the `claude` CLI default.
+
+Save as `EFFORT_CHOICE`. If `Skip`, leave unset.
+
+## Step 3 — Save location
+
+Use **AskUserQuestion** with `multiSelect: false`, header "Save to", question "Where should these defaults live?" and these options:
+
+- `User-global (~/.claude/cmux-tab-agents.toml)` — applies to every repo on this machine.
+- `This repo only (./.claude/cmux-tab-agents.toml)` — applies only when dispatching from inside this repo. Per-repo overrides user-global.
+- `Both` — write user-global first, then layer the per-repo file on top. Use this when you have a global default but one specific repo needs different settings (ask in Step 1/2 again or just confirm the per-repo file should mirror the global).
+
+Save as `SAVE_LOCATION`. If the user picked `This repo only` and we are not inside a git repo (`git rev-parse --show-toplevel` fails), fall back to user-global and tell them why.
+
+## Step 4 — Bonus: worktree base + branch type default
+
+While we're already in the config file, offer to also set the two existing worktree-related keys. Use **AskUserQuestion** with `multiSelect: true` and these options:
+
+- `Set worktree_base` — the directory where per-task worktrees are created. Default if unset: `<parent-of-repo>/worktrees/<repo-name>`.
+- `Set branch_type_default` — the prefix on auto-generated branch names (`feat/<TICKET>/<slug>`). Default if unset: `feat`.
+- `Skip both` (mutually exclusive — if checked, ignore the other two).
+
+For each one the user checked, ask a short follow-up:
+
+- For `worktree_base`: ask the path. Accept absolute or relative. Note in the prompt that relative paths resolve against the repo root.
+- For `branch_type_default`: ask the prefix. Common values: `feat`, `fix`, `chore`, `refactor`. Default if blank: `feat`.
+
+## Step 5 — Write the file(s)
+
+Determine the target path(s) from `SAVE_LOCATION`:
+
+- User-global: `$HOME/.claude/cmux-tab-agents.toml`.
+- Per-repo: `<repo-root>/.claude/cmux-tab-agents.toml` where `<repo-root>` is `git rev-parse --show-toplevel`.
+
+For each target:
+
+1. If the file exists, read it. **Preserve any keys we are not changing.** Replace only the keys this wizard is responsible for (`default_model`, `default_effort`, `worktree_base`, `branch_type_default`). Use a section comment `# managed by /cmux-tab-agents:setup` only on a fresh file — do not add it to an already-existing file.
+2. Write the file with the merged content. Quote string values with double quotes.
+3. After writing, `git check-ignore` the file path (per-repo only) — if it's not ignored, mention to the user that they may want to add `.claude/cmux-tab-agents.toml` to `.gitignore` (or commit it deliberately, depending on whether the repo wants shared per-repo defaults).
+
+Sample fresh-file body (illustrative — only emit the keys the user actually set):
+
+```toml
+# managed by /cmux-tab-agents:setup
+default_model = "claude-sonnet-4-6"
+default_effort = "high"
+worktree_base = "../worktrees"
+branch_type_default = "feat"
+```
+
+## Step 6 — Confirmation
+
+Echo back, on one line each, every key actually written and where it landed. Example:
+
+```
+default_model = claude-sonnet-4-6   → /Users/you/.claude/cmux-tab-agents.toml
+default_effort = high               → /Users/you/.claude/cmux-tab-agents.toml
+```
+
+Then, in 4–5 lines, restate the resolution order so the user knows how to override later:
+
+```
+Resolution order at dispatch time (first match wins):
+  1. CLI flag (--model / --effort)
+  2. Env var (CMUX_TAB_AGENTS_DEFAULT_MODEL / CMUX_TAB_AGENTS_DEFAULT_EFFORT)
+  3. Per-repo:    <repo>/.claude/cmux-tab-agents.toml
+  4. User-global: ~/.claude/cmux-tab-agents.toml
+  5. Unset       (claude CLI default)
+```
+
+That's it. Stop. Do not dispatch any agents — this command only writes config.
+
+## Failure modes
+
+- **Not inside a git repo, user picked per-repo or both:** fall back to user-global. Explain why in one line.
+- **TOML file contains lines we can't parse (multi-line array, complex tables):** preserve those lines verbatim, only update the flat keys this wizard owns. If you genuinely cannot determine where a key lives, abort with a clear message asking the user to edit by hand and showing them the path.
+- **User picks `Skip` for both model and effort and `Skip both` for the bonus:** there is nothing to write. Tell the user, do not create an empty file.

--- a/skills/cmux-tab-agents/SKILL.md
+++ b/skills/cmux-tab-agents/SKILL.md
@@ -18,6 +18,10 @@ Use this skill instead of upstream `superpowers:subagent-driven-development` whe
 
 If `$CMUX_SURFACE_ID` is empty, fall back to upstream `superpowers:subagent-driven-development`. The two skills have identical semantics, so the fallback path is safe.
 
+## First-run setup (optional)
+
+Run `/cmux-tab-agents:setup` once after install. It's an interactive wizard that asks for a default model and a default thinking-effort level, then writes them to `~/.claude/cmux-tab-agents.toml` (or a per-repo file). After this, every dispatch picks up these defaults — you don't have to repeat `--model` / `--effort` on each call. See `references/configuration.md` for the full layered-defaults resolution order. Skipping setup is fine; the plugin works without it (every dispatch falls through to the `claude` CLI's own defaults).
+
 ## What "the planner" means in this skill
 
 You are the planner. Your job is to:
@@ -135,9 +139,10 @@ The script:
 ### Optional flags shared by all three dispatch scripts
 
 - `--planner-surface <ref>` — surface ref where tab-agents should push their terminal-state line (see "How tab-agents talk to you" below). Defaults to the dispatcher's own surface, auto-detected via `cmux identify`. Pass explicitly only if you want the push to land somewhere other than where you ran the script.
-- `--model <model-id>` — override the Claude model the tab-agent's `claude` process runs with. Appended verbatim as `--model <id>` on the boot command. Omit to use the user's default. Use cheaper/faster models for mechanical tasks (e.g. `claude-haiku-4-5-20251001`) and stronger models for ambiguous design work, mirroring upstream `superpowers:subagent-driven-development`'s "Model Selection" guidance.
+- `--model <model-id>` — override the Claude model the tab-agent's `claude` process runs with. Appended verbatim as `--model <id>` on the boot command. Resolution order when omitted: env (`CMUX_TAB_AGENTS_DEFAULT_MODEL`) → per-repo TOML → user-global TOML → unset. Use cheaper/faster models for mechanical tasks (e.g. `claude-haiku-4-5-20251001`) and stronger models for ambiguous design work, mirroring upstream `superpowers:subagent-driven-development`'s "Model Selection" guidance.
+- `--effort <level>` — thinking-effort level for the tab-agent's `claude` process. One of `low | medium | high | xhigh | max`. Same resolution order as `--model` (env → per-repo → user-global → unset). Higher levels produce more reasoning at higher cost; pick to match task complexity.
 
-Both flags are backward-compatible: existing dispatch invocations without them keep working.
+All three flags are backward-compatible: existing dispatch invocations without them keep working. See `references/configuration.md` for the full layered-defaults model and `/cmux-tab-agents:setup` for an interactive way to set the defaults once and forget.
 
 ### Dispatch a spec-reviewer
 

--- a/skills/cmux-tab-agents/references/configuration.md
+++ b/skills/cmux-tab-agents/references/configuration.md
@@ -15,11 +15,12 @@ All three dispatch scripts (`dispatch-implementer.sh`, `dispatch-spec-reviewer.s
 | `--type TYPE`                      | no       | `feat` (or per-repo `branch_type_default`)       | Branch prefix: `feat`, `fix`, `chore`, etc. |
 | `--planner-workspace REF`          | no       | `$CMUX_WORKSPACE_ID` (the dispatcher's workspace)| Where status pills are mirrored. |
 | `--planner-surface REF`            | no       | dispatcher's own `surface_ref` from `cmux identify` | Where tab-agents push their one-line terminal-state message (see "How tab-agents talk to you" in `SKILL.md`). Pass `""` to disable the push channel and fall back to pure polling. |
-| `--model MODEL_ID`                 | no       | (omit — use user's default)                      | Override the Claude model the tab-agent's `claude` process runs with. Append-as-is to the boot command (`claude --model <id> ...`). Use cheaper/faster models for mechanical tasks (`claude-haiku-4-5-20251001`) and stronger models for ambiguous design work, mirroring upstream `superpowers:subagent-driven-development`'s Model Selection. |
+| `--model MODEL_ID`                 | no       | (resolved via env / config / unset — see "Layered defaults" below) | Override the Claude model the tab-agent's `claude` process runs with. Appended verbatim to the boot command (`claude --model <id> ...`). Use cheaper/faster models for mechanical tasks (`claude-haiku-4-5-20251001`) and stronger models for ambiguous design work, mirroring upstream `superpowers:subagent-driven-development`'s Model Selection. |
+| `--effort LEVEL`                   | no       | (resolved via env / config / unset — see "Layered defaults" below) | Thinking-effort level: `low`, `medium`, `high`, `xhigh`, or `max`. Appended verbatim to the boot command (`claude --effort <level> ...`). Higher levels = more reasoning steps and higher cost. |
 | `--implementer-sha SHA`            | no       | —                                                | Reviewer-only: the implementer's commit so the reviewer can scope its read. |
 | `--feedback-from-previous-review TEXT_OR_PATH` | no | — | On re-dispatch after a review found issues, pass the previous review's findings (literal text or readable file path). Wired into the seed prompt's "Feedback from a previous review" section. |
 
-All four optional knobs (`--type`, `--planner-workspace`, `--planner-surface`, `--model`, `--implementer-sha`, `--feedback-from-previous-review`) are backward-compatible — omitting them yields the same behavior as before each was added.
+All optional knobs (`--type`, `--planner-workspace`, `--planner-surface`, `--model`, `--effort`, `--implementer-sha`, `--feedback-from-previous-review`) are backward-compatible — omitting them yields the same behavior as before each was added.
 
 ### Examples
 
@@ -58,6 +59,33 @@ Disable the push channel entirely (pure polling):
   --planner-surface ""
 ```
 
+## Layered defaults for `--model` and `--effort`
+
+`v0.3.0+` resolves these two flags through a layered config so the planner doesn't have to repeat them on every dispatch. At dispatch time, the first non-empty value wins:
+
+1. **CLI flag** (`--model <id>` / `--effort <level>`).
+2. **Env var** (`CMUX_TAB_AGENTS_DEFAULT_MODEL` / `CMUX_TAB_AGENTS_DEFAULT_EFFORT`).
+3. **Per-repo TOML** at `<repo>/.claude/cmux-tab-agents.toml` — keys `default_model` / `default_effort`.
+4. **User-global TOML** at `~/.claude/cmux-tab-agents.toml` — same keys.
+5. **Unset** — the boot command omits the flag entirely; `claude` falls back to its own default.
+
+Example user-global config (`~/.claude/cmux-tab-agents.toml`):
+
+```toml
+default_model = "claude-sonnet-4-6"
+default_effort = "high"
+```
+
+Same keys are accepted in the per-repo file (`<repo>/.claude/cmux-tab-agents.toml`); per-repo wins over user-global on a key-by-key basis (you can set `default_model` per-repo while inheriting `default_effort` from user-global).
+
+The user-global file is sandboxed to your user account; the per-repo file may or may not be checked in (your call). If you commit it, every collaborator inherits the defaults; if you don't, add `.claude/cmux-tab-agents.toml` to `.gitignore`.
+
+For an interactive way to set these up, run `/cmux-tab-agents:setup` — it asks the questions, writes the file, and echoes back the resolved settings.
+
+### Valid values for `default_effort`
+
+`low`, `medium`, `high`, `xhigh`, `max`. Anything else causes dispatch to abort with a clear error pointing at the offending source.
+
 ## Env var: `CMUX_TAB_AGENTS_WORKTREE_BASE`
 
 Sets the base directory for all worktrees, globally. The actual worktree path becomes:
@@ -83,6 +111,14 @@ Optional. Create this file at the root of any repo where the defaults aren't rig
 ### Supported keys
 
 ```toml
+# Default Claude model for spawned tab-agents. Used when --model is omitted
+# on the cli AND CMUX_TAB_AGENTS_DEFAULT_MODEL is unset. See "Layered defaults".
+default_model = "claude-sonnet-4-6"
+
+# Default thinking-effort level for spawned tab-agents. low|medium|high|xhigh|max.
+# Used when --effort is omitted AND CMUX_TAB_AGENTS_DEFAULT_EFFORT is unset.
+default_effort = "high"
+
 # Worktree base directory. Relative paths are resolved against the repo root.
 # Absolute paths are used as-is.
 worktree_base = "../worktrees"
@@ -97,6 +133,8 @@ setup_command = "make bootstrap"
 # Validate the --ticket arg against this regex. Default: any non-empty string.
 ticket_pattern = "^[A-Z]+-[0-9]+(-[0-9]+)?$"
 ```
+
+The same file format is used for the user-global config at `~/.claude/cmux-tab-agents.toml`, but only `default_model` and `default_effort` are honored there (the others are repo-scoped by nature). Per-repo wins over user-global on a key-by-key basis.
 
 ### Resolution priority
 

--- a/skills/cmux-tab-agents/references/divergences-from-upstream.md
+++ b/skills/cmux-tab-agents/references/divergences-from-upstream.md
@@ -118,6 +118,18 @@ Implications:
 
 Override mechanism: same as v0.2.0 (`--planner-surface ""` on dispatch disables the channel both ways; the agent won't push and the planner has nowhere documented to reply, falling back to pure polling).
 
+### 14. Layered defaults for `--model` and `--effort` plus interactive setup (v0.3.0, additive)
+
+Upstream `superpowers:subagent-driven-development` exposes model selection as a per-call `model` parameter on `Agent({...})`. There is no notion of effort, no notion of layered defaults, and no setup wizard — the controller picks a model on every dispatch. This fork adds:
+
+- `--effort <level>` flag on all three dispatch wrappers and `_dispatch_common.sh`. Mirrors `--model` syntactically and is appended verbatim to the boot command. Levels: `low | medium | high | xhigh | max`. Validated at parse time; an invalid value aborts dispatch.
+- Layered defaults for both `--model` and `--effort`, resolved at dispatch time in this order: CLI → env → per-repo TOML → user-global TOML → unset. Implemented in `_dispatch_common.sh::resolve_default`. The new env vars are `CMUX_TAB_AGENTS_DEFAULT_MODEL` and `CMUX_TAB_AGENTS_DEFAULT_EFFORT`. The two new TOML keys are `default_model` and `default_effort`, accepted in both `<repo>/.claude/cmux-tab-agents.toml` (existing per-repo file) and `~/.claude/cmux-tab-agents.toml` (new user-global file).
+- `/cmux-tab-agents:setup` slash command (`commands/setup.md`) that walks a new user through picking the two defaults and a save location via `AskUserQuestion`, then writes the TOML file (preserving any keys it doesn't own) and echoes back the resolution order.
+
+Why this isn't in upstream: upstream's `Agent({...})` is one synchronous call site per task, so adding cli-style flags doesn't fit. This fork's dispatch is shell scripts; layered defaults plus an interactive setup are the natural ergonomics shell users expect.
+
+Backward compatibility: omitting all of the new flags / env vars / TOML keys produces a boot command identical to v0.2.x — verified by `scripts/tests/test-dispatch-integration.sh` case 5.
+
 ## Re-syncing
 
 When upstream `superpowers/X.Y.Z` ships:

--- a/skills/cmux-tab-agents/scripts/_dispatch_common.sh
+++ b/skills/cmux-tab-agents/scripts/_dispatch_common.sh
@@ -17,10 +17,84 @@ Usage: $0 --ticket TICKET --title TITLE --slug SLUG \\
           [--planner-workspace REF] \\
           [--planner-surface REF] \\
           [--model MODEL_ID] \\
+          [--effort LEVEL] \\
           [--implementer-sha SHA] \\
           [--feedback-from-previous-review TEXT_OR_PATH]
 EOF
   exit 1
+}
+
+# _read_toml_value <file> <key> — naive TOML-flat-key lookup. Echoes the value
+# (with surrounding "..." or '...' stripped) to stdout. Returns 1 if file is
+# missing or key is absent. Intentionally matches the parser used by
+# ensure-worktree.sh for consistency.
+_read_toml_value() {
+  local file="$1" key="$2"
+  [[ -f "$file" ]] || return 1
+  local line
+  line=$(grep -E "^[[:space:]]*${key}[[:space:]]*=" "$file" 2>/dev/null | head -1) || return 1
+  [[ -n "$line" ]] || return 1
+  printf '%s' "$line" \
+    | sed -E "s/^[[:space:]]*${key}[[:space:]]*=[[:space:]]*//" \
+    | sed -E 's/^"(.*)"$/\1/' \
+    | sed -E "s/^'(.*)'\$/\1/"
+}
+
+# resolve_default <toml_key> <env_var_name> <cli_value>
+# Returns the first non-empty value among (in order):
+#   1. <cli_value>
+#   2. ${<env_var_name>}                 (indirect expansion)
+#   3. <toml_key> in $REPO_CONFIG        (per-repo .claude/cmux-tab-agents.toml)
+#   4. <toml_key> in $USER_CONFIG        (user-global ~/.claude/cmux-tab-agents.toml)
+# Echoes empty if none set. Caller decides whether unset → flag-omitted.
+resolve_default() {
+  local key="$1" env_name="$2" cli="$3"
+  if [[ -n "$cli" ]]; then
+    printf '%s' "$cli"
+    return 0
+  fi
+  local env_val="${!env_name:-}"
+  if [[ -n "$env_val" ]]; then
+    printf '%s' "$env_val"
+    return 0
+  fi
+  local v
+  if [[ -n "${REPO_CONFIG:-}" && -f "${REPO_CONFIG:-}" ]]; then
+    if v=$(_read_toml_value "$REPO_CONFIG" "$key") && [[ -n "$v" ]]; then
+      printf '%s' "$v"
+      return 0
+    fi
+  fi
+  if [[ -n "${USER_CONFIG:-}" && -f "${USER_CONFIG:-}" ]]; then
+    if v=$(_read_toml_value "$USER_CONFIG" "$key") && [[ -n "$v" ]]; then
+      printf '%s' "$v"
+      return 0
+    fi
+  fi
+  printf ''
+}
+
+# resolved_boot_flags — emit the trailing " --model X --effort Y" segment of
+# the claude boot command. Reads $RESOLVED_MODEL / $RESOLVED_EFFORT from the
+# environment. Empty when neither is set; leading space when at least one is.
+resolved_boot_flags() {
+  local out=""
+  if [[ -n "${RESOLVED_MODEL:-}" ]]; then
+    out+=" --model ${RESOLVED_MODEL}"
+  fi
+  if [[ -n "${RESOLVED_EFFORT:-}" ]]; then
+    out+=" --effort ${RESOLVED_EFFORT}"
+  fi
+  printf '%s' "$out"
+}
+
+# claude_boot_command <worktree> <rendered_path> — emit the shell one-liner
+# that boots the tab-agent's claude process. Reads $RESOLVED_MODEL /
+# $RESOLVED_EFFORT via resolved_boot_flags.
+claude_boot_command() {
+  local wt="$1" rendered="$2"
+  printf 'cd %s && claude --dangerously-skip-permissions%s --append-system-prompt "$(cat %s)"' \
+    "$wt" "$(resolved_boot_flags)" "$rendered"
 }
 
 # render_template <src> <dst>  — substitutes {{KEY}} placeholders from env vars.
@@ -55,7 +129,7 @@ PY
 
 dispatch_main() {
   local TICKET="" TITLE="" SLUG="" TASK_TEXT="" TASK_FILE=""
-  local TYPE="" PLANNER_WS="" PLANNER_SURFACE="" MODEL="" IMPL_SHA="" FEEDBACK=""
+  local TYPE="" PLANNER_WS="" PLANNER_SURFACE="" MODEL="" EFFORT="" IMPL_SHA="" FEEDBACK=""
 
   while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -68,12 +142,20 @@ dispatch_main() {
       --planner-workspace)   PLANNER_WS="$2"; shift 2 ;;
       --planner-surface)     PLANNER_SURFACE="$2"; shift 2 ;;
       --model)               MODEL="$2"; shift 2 ;;
+      --effort)              EFFORT="$2"; shift 2 ;;
       --implementer-sha)     IMPL_SHA="$2"; shift 2 ;;
       --feedback-from-previous-review) FEEDBACK="$2"; shift 2 ;;
       -h|--help)             usage ;;
       *) echo "$0: unknown arg '$1'" >&2; usage ;;
     esac
   done
+
+  if [[ -n "$EFFORT" ]]; then
+    case "$EFFORT" in
+      low|medium|high|xhigh|max) ;;
+      *) echo "$0: --effort must be one of low|medium|high|xhigh|max (got '$EFFORT')" >&2; exit 1 ;;
+    esac
+  fi
 
   [[ -z "$TICKET" ]] && { echo "$0: --ticket required" >&2; usage; }
   [[ -z "$TITLE"  ]] && { echo "$0: --title required"  >&2; usage; }
@@ -144,6 +226,29 @@ print(d.get("caller",{}).get("pane_ref") or d.get("focused",{}).get("pane_ref","
     exit 1
   fi
 
+  # 1a. Resolve layered defaults for --model and --effort.
+  # Order: cli > env > per-repo TOML > user-global TOML > unset. The TOML
+  # files share the format documented in references/configuration.md.
+  local _REPO_ROOT
+  _REPO_ROOT=$(git -C "$PWD" rev-parse --show-toplevel 2>/dev/null) || _REPO_ROOT=""
+  local REPO_CONFIG="" USER_CONFIG="$HOME/.claude/cmux-tab-agents.toml"
+  [[ -n "$_REPO_ROOT" ]] && REPO_CONFIG="$_REPO_ROOT/.claude/cmux-tab-agents.toml"
+  export REPO_CONFIG USER_CONFIG
+  local RESOLVED_MODEL RESOLVED_EFFORT
+  RESOLVED_MODEL=$(resolve_default default_model CMUX_TAB_AGENTS_DEFAULT_MODEL "$MODEL")
+  RESOLVED_EFFORT=$(resolve_default default_effort CMUX_TAB_AGENTS_DEFAULT_EFFORT "$EFFORT")
+  if [[ -n "$RESOLVED_EFFORT" ]]; then
+    case "$RESOLVED_EFFORT" in
+      low|medium|high|xhigh|max) ;;
+      *)
+        echo "$0: resolved default_effort='$RESOLVED_EFFORT' is not one of low|medium|high|xhigh|max." >&2
+        echo "    Check $REPO_CONFIG and $USER_CONFIG, or unset CMUX_TAB_AGENTS_DEFAULT_EFFORT." >&2
+        exit 1
+        ;;
+    esac
+  fi
+  export RESOLVED_MODEL RESOLVED_EFFORT
+
   # 2. Render seed prompt for this phase.
   local TEMPLATE="$SKILL_ROOT/prompts/${PHASE}-tab-prompt.md"
   [[ -r "$TEMPLATE" ]] || { echo "$0: missing template $TEMPLATE" >&2; exit 1; }
@@ -183,11 +288,11 @@ print(d.get("caller",{}).get("pane_ref") or d.get("focused",{}).get("pane_ref","
   # we don't have to embed multi-KB of prompt text in a `cmux send` payload.
   # The shell prompt accepts \n as Enter (so cd && claude runs immediately);
   # we fire `send-key enter` separately as a safety net for terminals where
-  # the trailing newline is interpreted differently.
-  local model_flag=""
-  [[ -n "$MODEL" ]] && model_flag=" --model $MODEL"
-  cmux send --surface "$SURFACE" \
-    "cd $WT && claude --dangerously-skip-permissions${model_flag} --append-system-prompt \"\$(cat $RENDERED)\""$'\n'
+  # the trailing newline is interpreted differently. claude_boot_command reads
+  # $RESOLVED_MODEL / $RESOLVED_EFFORT and splices them into the boot string.
+  local BOOT
+  BOOT=$(claude_boot_command "$WT" "$RENDERED")
+  cmux send --surface "$SURFACE" "${BOOT}"$'\n'
   cmux send-key --surface "$SURFACE" enter >/dev/null 2>&1 || true
 
   # 5. Set initial dispatch pill on the planner's workspace.

--- a/skills/cmux-tab-agents/scripts/tests/run-all.sh
+++ b/skills/cmux-tab-agents/scripts/tests/run-all.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Run all dispatch script tests. Used by maintainers and (manually) before
+# release. Each test file is self-contained.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FAILED=0
+
+for t in "$SCRIPT_DIR"/test-*.sh; do
+  echo "==> $(basename "$t")"
+  if ! bash "$t"; then
+    FAILED=$((FAILED + 1))
+  fi
+  echo
+done
+
+if [[ $FAILED -gt 0 ]]; then
+  echo "$FAILED test file(s) failed"
+  exit 1
+fi
+echo "All test files passed."

--- a/skills/cmux-tab-agents/scripts/tests/test-boot-command.sh
+++ b/skills/cmux-tab-agents/scripts/tests/test-boot-command.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Test: resolved_boot_flags + claude_boot_command in _dispatch_common.sh.
+# These render the trailing "--model X --effort Y" segment and the full boot
+# one-liner that gets `cmux send` into the new tab.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+COMMON="$SCRIPT_DIR/../_dispatch_common.sh"
+[[ -r "$COMMON" ]] || { echo "missing $COMMON" >&2; exit 1; }
+
+PHASE="test"
+# shellcheck source=../_dispatch_common.sh
+source "$COMMON"
+set +e
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+  local got="$1" want="$2" msg="$3"
+  if [[ "$got" == "$want" ]]; then
+    echo "PASS  $msg"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL  $msg"
+    echo "  got:  '$got'"
+    echo "  want: '$want'"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# resolved_boot_flags
+got=$(RESOLVED_MODEL="" RESOLVED_EFFORT="" resolved_boot_flags)
+assert_eq "$got" "" "no model + no effort → empty"
+
+got=$(RESOLVED_MODEL="claude-opus-4-7" RESOLVED_EFFORT="" resolved_boot_flags)
+assert_eq "$got" " --model claude-opus-4-7" "model only"
+
+got=$(RESOLVED_MODEL="" RESOLVED_EFFORT="high" resolved_boot_flags)
+assert_eq "$got" " --effort high" "effort only"
+
+got=$(RESOLVED_MODEL="claude-haiku-4-5-20251001" RESOLVED_EFFORT="medium" resolved_boot_flags)
+assert_eq "$got" " --model claude-haiku-4-5-20251001 --effort medium" "model + effort"
+
+# claude_boot_command — full one-liner.
+got=$(RESOLVED_MODEL="" RESOLVED_EFFORT="" \
+  claude_boot_command "/tmp/wt" "/tmp/wt/.cmux-tab-prompt-implementer.md")
+want='cd /tmp/wt && claude --dangerously-skip-permissions --append-system-prompt "$(cat /tmp/wt/.cmux-tab-prompt-implementer.md)"'
+assert_eq "$got" "$want" "boot command: no flags resolved"
+
+got=$(RESOLVED_MODEL="claude-sonnet-4-6" RESOLVED_EFFORT="high" \
+  claude_boot_command "/tmp/wt" "/tmp/wt/.cmux-tab-prompt-implementer.md")
+want='cd /tmp/wt && claude --dangerously-skip-permissions --model claude-sonnet-4-6 --effort high --append-system-prompt "$(cat /tmp/wt/.cmux-tab-prompt-implementer.md)"'
+assert_eq "$got" "$want" "boot command: model + effort"
+
+got=$(RESOLVED_MODEL="" RESOLVED_EFFORT="xhigh" \
+  claude_boot_command "/tmp/wt" "/tmp/wt/x.md")
+want='cd /tmp/wt && claude --dangerously-skip-permissions --effort xhigh --append-system-prompt "$(cat /tmp/wt/x.md)"'
+assert_eq "$got" "$want" "boot command: effort only"
+
+echo
+echo "$PASS passed, $FAIL failed"
+[[ $FAIL -eq 0 ]]

--- a/skills/cmux-tab-agents/scripts/tests/test-dispatch-integration.sh
+++ b/skills/cmux-tab-agents/scripts/tests/test-dispatch-integration.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+# Integration test: end-to-end run of dispatch-implementer.sh with stubbed
+# `cmux` and a real (temp) git repo. Verifies that the boot string sent into
+# the spawned tab carries the expected --model / --effort flags resolved from
+# CLI / env / per-repo TOML / user-global TOML.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DISPATCH="$SCRIPT_DIR/../dispatch-implementer.sh"
+[[ -x "$DISPATCH" ]] || { echo "missing $DISPATCH" >&2; exit 1; }
+
+PASS=0
+FAIL=0
+
+assert_contains() {
+  local hay="$1" needle="$2" msg="$3"
+  if [[ "$hay" == *"$needle"* ]]; then
+    echo "PASS  $msg"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL  $msg"
+    echo "  haystack: $hay"
+    echo "  needle:   $needle"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_not_contains() {
+  local hay="$1" needle="$2" msg="$3"
+  if [[ "$hay" != *"$needle"* ]]; then
+    echo "PASS  $msg"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL  $msg"
+    echo "  haystack: $hay"
+    echo "  forbidden:$needle"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# Build a sandbox: one temp dir holding the fake repo, the fake home, the
+# stub cmux binary, and the captured boot string.
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+# Fake HOME so user-global config lookup is sandboxed.
+FAKE_HOME="$TMP/home"
+mkdir -p "$FAKE_HOME/.claude"
+
+# Stub cmux: capture every `cmux send` payload to $TMP/sent.log, fake JSON for
+# `cmux --json identify` and `cmux --json new-surface`. Everything else is a
+# silent no-op.
+STUB_BIN="$TMP/bin"
+mkdir -p "$STUB_BIN"
+cat >"$STUB_BIN/cmux" <<EOF
+#!/usr/bin/env bash
+out_file="$TMP/sent.log"
+case "\$*" in
+  *"--json identify"*)
+    cat <<'JSON'
+{"caller":{"surface_ref":"surface:99","pane_ref":"pane:1"},"focused":{"surface_ref":"surface:99","pane_ref":"pane:1"}}
+JSON
+    ;;
+  *"--json new-surface"*)
+    echo '{"surface_ref":"surface:100"}'
+    ;;
+  send\\ --surface*)
+    # capture the payload (last positional arg)
+    last=""
+    while [[ \$# -gt 0 ]]; do last="\$1"; shift; done
+    printf '%s\n' "\$last" >>"\$out_file"
+    ;;
+  *)
+    : # silent no-op for set-status / log / rename-tab / send-key / notify
+    ;;
+esac
+exit 0
+EOF
+chmod +x "$STUB_BIN/cmux"
+
+# Build a fake git repo with a .claude/cmux-tab-agents.toml.
+REPO="$TMP/repo"
+mkdir -p "$REPO/.claude"
+git -C "$REPO" init -q
+git -C "$REPO" -c user.email=t@t -c user.name=t commit --allow-empty -q -m initial
+cat >"$REPO/.claude/cmux-tab-agents.toml" <<'EOF'
+default_model = "from-per-repo"
+default_effort = "high"
+EOF
+
+cat >"$FAKE_HOME/.claude/cmux-tab-agents.toml" <<'EOF'
+default_model = "from-user-global"
+default_effort = "low"
+EOF
+
+run_dispatch() {
+  : >"$TMP/sent.log"
+  (
+    cd "$REPO"
+    PATH="$STUB_BIN:$PATH" HOME="$FAKE_HOME" CMUX_WORKSPACE_ID="ws-1" \
+      "$DISPATCH" \
+      --ticket FOO-1 \
+      --title "smoke" \
+      --slug smoke \
+      --task-text "noop" \
+      "$@" \
+      >/dev/null 2>"$TMP/dispatch.err"
+  )
+}
+
+# Case 1: per-repo TOML wins when no CLI / env override.
+unset CMUX_TAB_AGENTS_DEFAULT_MODEL CMUX_TAB_AGENTS_DEFAULT_EFFORT
+run_dispatch
+sent=$(cat "$TMP/sent.log" 2>/dev/null)
+assert_contains "$sent" "--model from-per-repo" "case 1: per-repo model wins"
+assert_contains "$sent" "--effort high" "case 1: per-repo effort wins"
+
+# Case 2: env var overrides per-repo.
+CMUX_TAB_AGENTS_DEFAULT_MODEL="from-env-model" \
+CMUX_TAB_AGENTS_DEFAULT_EFFORT="medium" \
+  run_dispatch
+sent=$(cat "$TMP/sent.log")
+assert_contains "$sent" "--model from-env-model" "case 2: env model wins"
+assert_contains "$sent" "--effort medium"        "case 2: env effort wins"
+assert_not_contains "$sent" "from-per-repo" "case 2: per-repo model not used"
+unset CMUX_TAB_AGENTS_DEFAULT_MODEL CMUX_TAB_AGENTS_DEFAULT_EFFORT
+
+# Case 3: CLI flag wins over env + per-repo.
+CMUX_TAB_AGENTS_DEFAULT_MODEL="env-loser" \
+  run_dispatch --model claude-opus-4-7 --effort xhigh
+sent=$(cat "$TMP/sent.log")
+assert_contains "$sent" "--model claude-opus-4-7" "case 3: CLI model wins"
+assert_contains "$sent" "--effort xhigh"          "case 3: CLI effort wins"
+assert_not_contains "$sent" "env-loser"           "case 3: env model ignored"
+unset CMUX_TAB_AGENTS_DEFAULT_MODEL
+
+# Case 4: user-global TOML used when per-repo missing.
+rm -f "$REPO/.claude/cmux-tab-agents.toml"
+run_dispatch
+sent=$(cat "$TMP/sent.log")
+assert_contains "$sent" "--model from-user-global" "case 4: user-global model used"
+assert_contains "$sent" "--effort low"             "case 4: user-global effort used"
+
+# Case 5: no config anywhere → no flags emitted.
+rm -f "$FAKE_HOME/.claude/cmux-tab-agents.toml"
+run_dispatch
+sent=$(cat "$TMP/sent.log")
+assert_not_contains "$sent" "--model"  "case 5: no model flag"
+assert_not_contains "$sent" "--effort" "case 5: no effort flag"
+assert_contains "$sent" "claude --dangerously-skip-permissions --append-system-prompt" \
+  "case 5: backward-compat boot string"
+
+# Case 6: invalid --effort rejected.
+echo "default_model = \"x\"" >"$FAKE_HOME/.claude/cmux-tab-agents.toml"
+if run_dispatch --effort wat; then
+  echo "FAIL  case 6: invalid --effort should exit non-zero"
+  FAIL=$((FAIL + 1))
+else
+  echo "PASS  case 6: invalid --effort rejected"
+  PASS=$((PASS + 1))
+fi
+
+echo
+echo "$PASS passed, $FAIL failed"
+[[ $FAIL -eq 0 ]]

--- a/skills/cmux-tab-agents/scripts/tests/test-resolve-defaults.sh
+++ b/skills/cmux-tab-agents/scripts/tests/test-resolve-defaults.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# Test: resolve_default in _dispatch_common.sh.
+# Resolution order: cli > env > per-repo TOML > user-global TOML > empty.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+COMMON="$SCRIPT_DIR/../_dispatch_common.sh"
+[[ -r "$COMMON" ]] || { echo "missing $COMMON" >&2; exit 1; }
+
+PHASE="test"
+# shellcheck source=../_dispatch_common.sh
+source "$COMMON"
+set +e
+
+PASS=0
+FAIL=0
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+assert_eq() {
+  local got="$1" want="$2" msg="$3"
+  if [[ "$got" == "$want" ]]; then
+    echo "PASS  $msg"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL  $msg"
+    echo "  got:  '$got'"
+    echo "  want: '$want'"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+REPO_CFG="$TMP/repo.toml"
+USER_CFG="$TMP/user.toml"
+cat >"$REPO_CFG" <<'EOF'
+default_model = "claude-sonnet-4-6"
+default_effort = "high"
+EOF
+cat >"$USER_CFG" <<'EOF'
+default_model = "claude-haiku-4-5-20251001"
+default_effort = "medium"
+EOF
+
+unset CMUX_TAB_AGENTS_DEFAULT_MODEL CMUX_TAB_AGENTS_DEFAULT_EFFORT
+
+# 1. CLI wins over env + both configs.
+got=$(REPO_CONFIG="$REPO_CFG" USER_CONFIG="$USER_CFG" \
+  CMUX_TAB_AGENTS_DEFAULT_MODEL="from-env" \
+  resolve_default default_model CMUX_TAB_AGENTS_DEFAULT_MODEL "from-cli")
+assert_eq "$got" "from-cli" "CLI > env > configs"
+
+# 2. env wins over both configs when CLI empty.
+got=$(REPO_CONFIG="$REPO_CFG" USER_CONFIG="$USER_CFG" \
+  CMUX_TAB_AGENTS_DEFAULT_MODEL="from-env" \
+  resolve_default default_model CMUX_TAB_AGENTS_DEFAULT_MODEL "")
+assert_eq "$got" "from-env" "env > per-repo > user-global"
+
+# 3. per-repo wins over user-global when CLI + env empty.
+got=$(REPO_CONFIG="$REPO_CFG" USER_CONFIG="$USER_CFG" \
+  resolve_default default_model CMUX_TAB_AGENTS_DEFAULT_MODEL "")
+assert_eq "$got" "claude-sonnet-4-6" "per-repo > user-global"
+
+# 4. user-global is consulted when per-repo is empty/unset.
+got=$(REPO_CONFIG="" USER_CONFIG="$USER_CFG" \
+  resolve_default default_model CMUX_TAB_AGENTS_DEFAULT_MODEL "")
+assert_eq "$got" "claude-haiku-4-5-20251001" "user-global when no per-repo"
+
+# 5. empty when nothing set anywhere.
+got=$(REPO_CONFIG="" USER_CONFIG="" \
+  resolve_default default_model CMUX_TAB_AGENTS_DEFAULT_MODEL "")
+assert_eq "$got" "" "empty when nothing set"
+
+# 6. effort uses the same machinery.
+got=$(REPO_CONFIG="$REPO_CFG" USER_CONFIG="$USER_CFG" \
+  resolve_default default_effort CMUX_TAB_AGENTS_DEFAULT_EFFORT "")
+assert_eq "$got" "high" "effort: per-repo > user-global"
+
+# 7. effort env override.
+got=$(REPO_CONFIG="$REPO_CFG" USER_CONFIG="$USER_CFG" \
+  CMUX_TAB_AGENTS_DEFAULT_EFFORT="xhigh" \
+  resolve_default default_effort CMUX_TAB_AGENTS_DEFAULT_EFFORT "")
+assert_eq "$got" "xhigh" "effort: env > configs"
+
+# 8. per-repo file with only one key, user-global with both — fall through per key.
+PARTIAL_REPO="$TMP/partial-repo.toml"
+cat >"$PARTIAL_REPO" <<'EOF'
+default_model = "only-model-here"
+EOF
+got=$(REPO_CONFIG="$PARTIAL_REPO" USER_CONFIG="$USER_CFG" \
+  resolve_default default_effort CMUX_TAB_AGENTS_DEFAULT_EFFORT "")
+assert_eq "$got" "medium" "per-key fall-through: missing in repo, present in user-global"
+
+# 9. quoted single-quote values are unwrapped.
+SQ_CFG="$TMP/sq.toml"
+cat >"$SQ_CFG" <<'EOF'
+default_effort = 'low'
+EOF
+got=$(REPO_CONFIG="" USER_CONFIG="$SQ_CFG" \
+  resolve_default default_effort CMUX_TAB_AGENTS_DEFAULT_EFFORT "")
+assert_eq "$got" "low" "single-quoted value unwrapped"
+
+echo
+echo "$PASS passed, $FAIL failed"
+[[ $FAIL -eq 0 ]]


### PR DESCRIPTION
## Summary

Closes #8.

- Adds `--effort <low|medium|high|xhigh|max>` flag on all three dispatch wrappers and `_dispatch_common.sh`, mirroring `--model`.
- Both `--model` and `--effort` now resolve through a layered config at dispatch time: **CLI > env (`CMUX_TAB_AGENTS_DEFAULT_MODEL` / `CMUX_TAB_AGENTS_DEFAULT_EFFORT`) > per-repo `<repo>/.claude/cmux-tab-agents.toml` > user-global `~/.claude/cmux-tab-agents.toml` > unset**. The two new TOML keys are `default_model` and `default_effort`.
- New `/cmux-tab-agents:setup` slash command (`commands/setup.md`) walks a fresh user through picking the two defaults via `AskUserQuestion` and writes the file.
- Updated `references/configuration.md` with the layered-defaults section and key reference, added a v0.3.0 entry to `references/divergences-from-upstream.md`, and SKILL.md now mentions `/cmux-tab-agents:setup` in the install/quickstart.
- Bumped `plugin.json` and `marketplace.json` to `0.3.0`.

Backward-compatible: omitting all of the new flags / env vars / TOML keys produces a boot string identical to v0.2.x — see `test-dispatch-integration.sh` case 5.

## Stacking

Stacks on #7 (v0.2.1 bidirectional). Targeting `feat/issue-6/bidirectional-conversation` for now; rebase onto `main` once #7 merges.

## Test plan

- [x] `bash skills/cmux-tab-agents/scripts/tests/run-all.sh` — 30 cases across 3 files, all green:
  - `test-resolve-defaults.sh` (9): full resolution-order matrix.
  - `test-boot-command.sh` (7): rendering of `--model X --effort Y` in the boot one-liner, including the empty case.
  - `test-dispatch-integration.sh` (14): end-to-end `dispatch-implementer.sh` with stubbed `cmux` + a temp git repo, asserts `cmux send` payload picks up the right flag from each layer, plus invalid `--effort` rejection.
- [x] `bash -n` syntax check on all four modified scripts.
- [x] Backward-compat verified (case 5 of the integration test): no flags, no env, no TOML → identical boot string to v0.2.x.
- [ ] Manual smoke: run `/cmux-tab-agents:setup` once installed, confirm the wizard writes a valid TOML and the next dispatch picks it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)