### PR TITLE
Add local dev environment + auto-start + push channel + CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,59 @@
+# Contributing
+
+Contributions are welcome. This document covers how to propose changes, the commit style, and the hard rules every contributor must follow.
+
+## Quick start for contributors
+
+- Clone the repo and run `make link` to symlink your checkout into the plugin cache.
+- Edit files under `skills/cmux-tab-agents/`.
+- Run `make lint` before committing.
+- Run `make preview` to render the implementer prompt with sample values.
+
+Full setup and iteration loop: [README — Local development](./README.md#local-development).
+
+## Proposing changes
+
+`main` is branch-protected. Direct pushes are blocked. All changes go via PR.
+
+1. Branch from `main`. Conventional name: `<type>/<ticket-or-slug>` — e.g. `feat/CTADEV-42/add-x`, `fix/issue-7/parse-bug`, `docs/CTADEV-11/add-contributing`.
+2. Push and open a PR: `gh pr create`.
+3. PRs merge with 0 required approving reviews (solo-friendly), but the protection rule means you cannot bypass via direct push. Force-push and branch delete on `main` are also blocked.
+
+## Commit style
+
+Conventional commits. Subject under 72 characters. Body explains WHY, not WHAT.
+
+Allowed types: `feat`, `fix`, `docs`, `refactor`, `chore`, `test`.
+
+Scope is optional but preferred: `feat(skill): ...`, `fix(dev): ...`, `docs(readme): ...`.
+
+Recent examples from the log:
+
+```
+fix(skill): auto-start tab-agents via initial user message
+refactor(dev): link/unlink also handle legacy ~/.claude/skills/ path
+docs(readme): add local development prerequisites
+```
+
+## TDD discipline
+
+Write the failing test first. Watch it fail. Write minimal code to pass. No production code without a failing test.
+
+Full rationale, the Iron Law, and Red-Green-Refactor detail: [`skills/cmux-tab-agents/prompts/implementer-tab-prompt.md`](./skills/cmux-tab-agents/prompts/implementer-tab-prompt.md). That file is the source of truth for the project's TDD position — this document does not duplicate it.
+
+## Hook bypass is forbidden
+
+NEVER use `git commit --no-verify`, `HUSKY=0`, `--no-gpg-sign`, `-c core.hooksPath=/dev/null`, or any equivalent. If a hook fails, read the failure and fix the underlying issue. Reviewers scan commits for evidence of bypass.
+
+## Optional: dogfood the skill
+
+For non-trivial changes, the maintainer runs the change through the plugin's own pipeline — implementer tab-agent, then spec-reviewer, then code-quality-reviewer. You don't need to do this yourself; a clean PR with a focused diff and tests is enough. If you developed your fix via the pipeline and want to mention that in the PR description, go for it.
+
+## Filing issues
+
+Open an issue on [GitHub Issues](https://github.com/AhmedElBanna80/cmux-tab-agents/issues). Include:
+
+- Reproduction steps
+- Expected vs. actual behavior
+- `cmux --version` output (if available)
+- Claude Code version

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+.PHONY: help link unlink status
+
+help:
+	@printf '%s\n' \
+	  'cmux-tab-agents — local dev targets' \
+	  '' \
+	  '  make help     show this help (default)' \
+	  '  make link     symlink this checkout into ~/.claude/plugins/cache/...' \
+	  '  make unlink   remove the symlink (does not auto-restore backups)' \
+	  '  make status   show whether the plugin is linked to this checkout'
+
+link:
+	@bash scripts/dev/link.sh
+
+unlink:
+	@bash scripts/dev/unlink.sh
+
+status:
+	@bash scripts/dev/status.sh

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help link unlink status
+.PHONY: help link unlink status lint preview
 
 help:
 	@printf '%s\n' \
@@ -7,7 +7,9 @@ help:
 	  '  make help     show this help (default)' \
 	  '  make link     symlink this checkout into ~/.claude/plugins/cache/...' \
 	  '  make unlink   remove the symlink (does not auto-restore backups)' \
-	  '  make status   show whether the plugin is linked to this checkout'
+	  '  make status   show whether the plugin is linked to this checkout' \
+	  '  make lint     run shellcheck + JSON + prompt-template lint' \
+	  '  make preview  preview the implementer prompt with sample values'
 
 link:
 	@bash scripts/dev/link.sh
@@ -17,3 +19,9 @@ unlink:
 
 status:
 	@bash scripts/dev/status.sh
+
+lint:
+	@bash scripts/dev/lint.sh
+
+preview:
+	@bash scripts/dev/render-prompt.sh implementer

--- a/README.md
+++ b/README.md
@@ -179,6 +179,10 @@ Every dispatched tab-agent is bound by these (verbatim from the seed prompts):
 - **`git commit --no-verify`, `--no-gpg-sign`, `HUSKY=0`, hook-config overrides, and creative hook-shaped escape hatches are FORBIDDEN.** If a hook fails, fix the underlying code or escalate as `BLOCKED`. Do not commit.
 - Stay inside the worktree. Never edit files in the parent repo. Never push, merge, or open PRs — that's the planner's call.
 
+## Contributing
+
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for how to propose changes, the TDD requirements, the no-hook-bypass rule, and the conventional commit style.
+
 ## License
 
 MIT — see [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -82,6 +82,69 @@ The planner will:
 
 You can run all of step 1 in parallel — different worktrees, no conflicts.
 
+## Local development
+
+Iterate on this plugin in-place — no marketplace re-install loop.
+
+### Prerequisites
+
+- `bash` 3.2+ (macOS default works)
+- `jq` — required by link/unlink/status (`brew install jq`)
+- `python3` — required by `render-prompt.sh` and the template lint in `lint.sh` (preinstalled on macOS)
+- `shellcheck` — recommended, optional (`brew install shellcheck`); `make lint` warns and skips the shell-lint sub-check when it isn't installed
+- `make` — entry point (preinstalled on macOS via the Xcode CLT)
+
+### The loop
+
+1. Link this checkout into the plugin cache:
+
+   ```sh
+   make link
+   ```
+
+   This symlinks the checkout into `~/.claude/plugins/cache/<marketplace>/<plugin>/<version>/`. If a real install is already there, it's renamed to `<target>.bak-<timestamp>` so you can restore it later.
+
+2. Edit files under `skills/cmux-tab-agents/`. Changes are live — no re-install needed.
+
+3. Lint:
+
+   ```sh
+   make lint
+   ```
+
+   Runs shellcheck (if installed) + jq JSON validation + the prompt-template lint (catches stray `{{TYPO}}` placeholders).
+
+4. Preview the rendered implementer prompt with sample values:
+
+   ```sh
+   make preview
+   ```
+
+   For other phases, call the renderer directly:
+
+   ```sh
+   scripts/dev/render-prompt.sh spec-reviewer --values TICKET=TEST-1,TASK="dummy"
+   scripts/dev/render-prompt.sh code-reviewer
+   ```
+
+5. In a real cmux session, exercise `/cmux-tab-agents` against a sample ticket to test the live dispatch end-to-end.
+
+6. Unlink when done:
+
+   ```sh
+   make unlink
+   ```
+
+   Removes the symlink. If a `.bak-<timestamp>` exists, the script prints the manual `mv` command to restore it. To switch back to the published version: `/plugin install cmux-tab-agents@cmux-tab-agents`.
+
+`make status` shows the current state at any time — `linked` (and to where), `installed (not linked)`, or `not installed`.
+
+### What the tooling does NOT cover
+
+- No end-to-end smoke test that actually dispatches a tab-agent (would require a real cmux session and a throwaway repo). Run `/cmux-tab-agents` manually.
+- No CI on PRs — linting is local-only.
+- The `cmux <subcmd>` calls inside the dispatch scripts are not mocked.
+
 ## How tab-agents report back
 
 Three out-of-band channels per phase:

--- a/scripts/dev/_target-path.sh
+++ b/scripts/dev/_target-path.sh
@@ -9,10 +9,9 @@
 # When executed directly, prints the computed target path. When sourced, the
 # functions become available without enabling strict mode in the caller.
 
-compute_target_path() {
-  local repo_root manifest name version cache_root marketplace
-  local matches=()
-  local d
+# Private. Echoes "<name> <version>" or returns 1 with a message on stderr.
+_read_manifest_fields() {
+  local repo_root manifest name version
 
   if ! repo_root=$(git rev-parse --show-toplevel 2>/dev/null); then
     echo "error: not inside a git repository" >&2
@@ -37,6 +36,18 @@ compute_target_path() {
     echo "error: could not read name/version from ${manifest}" >&2
     return 1
   fi
+
+  echo "$name $version"
+}
+
+compute_target_path() {
+  local fields name version cache_root marketplace
+  local matches=()
+  local d
+
+  fields=$(_read_manifest_fields) || return 1
+  name=${fields%% *}
+  version=${fields##* }
 
   cache_root="${HOME}/.claude/plugins/cache"
 
@@ -63,29 +74,10 @@ compute_target_path() {
 }
 
 compute_legacy_target_path() {
-  local repo_root manifest name
+  local fields name
 
-  if ! repo_root=$(git rev-parse --show-toplevel 2>/dev/null); then
-    echo "error: not inside a git repository" >&2
-    return 1
-  fi
-
-  manifest="${repo_root}/.claude-plugin/plugin.json"
-  if [[ ! -f "$manifest" ]]; then
-    echo "error: ${manifest} not found" >&2
-    return 1
-  fi
-
-  if ! command -v jq >/dev/null 2>&1; then
-    echo "error: jq is required (install via: brew install jq)" >&2
-    return 1
-  fi
-
-  name=$(jq -r '.name' "$manifest")
-  if [[ -z "$name" || "$name" == "null" ]]; then
-    echo "error: could not read name from ${manifest}" >&2
-    return 1
-  fi
+  fields=$(_read_manifest_fields) || return 1
+  name=${fields%% *}
 
   echo "${HOME}/.claude/skills/${name}"
 }

--- a/scripts/dev/_target-path.sh
+++ b/scripts/dev/_target-path.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Shared helper for link.sh, unlink.sh, and status.sh.
+#
+# Defines:
+#   compute_target_path        - prints the absolute plugin-cache target path
+#   resolve_symlink_target     - prints the absolute target a symlink points at
+#
+# When executed directly, prints the computed target path. When sourced, the
+# functions become available without enabling strict mode in the caller.
+
+compute_target_path() {
+  local repo_root manifest name version cache_root marketplace
+  local matches=()
+  local d
+
+  if ! repo_root=$(git rev-parse --show-toplevel 2>/dev/null); then
+    echo "error: not inside a git repository" >&2
+    return 1
+  fi
+
+  manifest="${repo_root}/.claude-plugin/plugin.json"
+  if [[ ! -f "$manifest" ]]; then
+    echo "error: ${manifest} not found" >&2
+    return 1
+  fi
+
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "error: jq is required (install via: brew install jq)" >&2
+    return 1
+  fi
+
+  name=$(jq -r '.name' "$manifest")
+  version=$(jq -r '.version' "$manifest")
+
+  if [[ -z "$name" || "$name" == "null" || -z "$version" || "$version" == "null" ]]; then
+    echo "error: could not read name/version from ${manifest}" >&2
+    return 1
+  fi
+
+  cache_root="${HOME}/.claude/plugins/cache"
+
+  if [[ -d "$cache_root" ]]; then
+    for d in "$cache_root"/*/; do
+      [[ -d "$d" ]] || continue
+      if [[ -d "${d}${name}" ]]; then
+        matches+=("$(basename "$d")")
+      fi
+    done
+  fi
+
+  if [[ ${#matches[@]} -eq 1 ]]; then
+    marketplace="${matches[0]}"
+  elif [[ ${#matches[@]} -gt 1 ]]; then
+    echo "error: multiple marketplace dirs contain '${name}': ${matches[*]}" >&2
+    echo "  remove the unwanted ones to disambiguate" >&2
+    return 1
+  else
+    marketplace="$name"
+  fi
+
+  echo "${cache_root}/${marketplace}/${name}/${version}"
+}
+
+resolve_symlink_target() {
+  local link="$1"
+  local current
+  current=$(readlink "$link")
+  if [[ "$current" != /* ]]; then
+    current="$(cd "$(dirname "$link")" && cd "$current" 2>/dev/null && pwd)" || current=""
+  fi
+  echo "$current"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  set -euo pipefail
+  compute_target_path
+fi

--- a/scripts/dev/_target-path.sh
+++ b/scripts/dev/_target-path.sh
@@ -3,6 +3,7 @@
 #
 # Defines:
 #   compute_target_path        - prints the absolute plugin-cache target path
+#   compute_legacy_target_path - prints the absolute legacy ~/.claude/skills/ target path
 #   resolve_symlink_target     - prints the absolute target a symlink points at
 #
 # When executed directly, prints the computed target path. When sourced, the
@@ -59,6 +60,34 @@ compute_target_path() {
   fi
 
   echo "${cache_root}/${marketplace}/${name}/${version}"
+}
+
+compute_legacy_target_path() {
+  local repo_root manifest name
+
+  if ! repo_root=$(git rev-parse --show-toplevel 2>/dev/null); then
+    echo "error: not inside a git repository" >&2
+    return 1
+  fi
+
+  manifest="${repo_root}/.claude-plugin/plugin.json"
+  if [[ ! -f "$manifest" ]]; then
+    echo "error: ${manifest} not found" >&2
+    return 1
+  fi
+
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "error: jq is required (install via: brew install jq)" >&2
+    return 1
+  fi
+
+  name=$(jq -r '.name' "$manifest")
+  if [[ -z "$name" || "$name" == "null" ]]; then
+    echo "error: could not read name from ${manifest}" >&2
+    return 1
+  fi
+
+  echo "${HOME}/.claude/skills/${name}"
 }
 
 resolve_symlink_target() {

--- a/scripts/dev/link.sh
+++ b/scripts/dev/link.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=_target-path.sh
+source "${script_dir}/_target-path.sh"
+
+repo_root=$(git rev-parse --show-toplevel)
+target=$(compute_target_path)
+
+mkdir -p "$(dirname "$target")"
+
+if [[ -L "$target" ]]; then
+  current=$(resolve_symlink_target "$target")
+  if [[ "$current" == "$repo_root" ]]; then
+    echo "already linked: $target -> $repo_root"
+    exit 0
+  fi
+  echo "removing existing symlink: $target -> $current"
+  rm "$target"
+elif [[ -e "$target" ]]; then
+  ts=$(date +%s)
+  backup="${target}.bak-${ts}"
+  mv "$target" "$backup"
+  echo "backed up real install to: $backup"
+fi
+
+ln -s "$repo_root" "$target"
+echo "linked: $target -> $repo_root"
+echo "restart Claude Code (or /plugin reload) to pick up changes if needed"

--- a/scripts/dev/link.sh
+++ b/scripts/dev/link.sh
@@ -6,25 +6,51 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${script_dir}/_target-path.sh"
 
 repo_root=$(git rev-parse --show-toplevel)
-target=$(compute_target_path)
 
-mkdir -p "$(dirname "$target")"
+# Link a single target path to the given source path.
+# Prints outcome. Returns 1 on failure, 0 on success.
+link_one() {
+  local target="$1"
+  local source="$2"
 
-if [[ -L "$target" ]]; then
-  current=$(resolve_symlink_target "$target")
-  if [[ "$current" == "$repo_root" ]]; then
-    echo "already linked: $target -> $repo_root"
-    exit 0
+  mkdir -p "$(dirname "$target")"
+
+  if [[ -L "$target" ]]; then
+    local current
+    current=$(resolve_symlink_target "$target")
+    if [[ "$current" == "$source" ]]; then
+      echo "already linked: $target -> $source"
+      return 0
+    fi
+    echo "removing existing symlink: $target -> $current"
+    rm "$target"
+  elif [[ -e "$target" ]]; then
+    local ts backup
+    ts=$(date +%s)
+    backup="${target}.bak-${ts}"
+    mv "$target" "$backup"
+    echo "backed up real install to: $backup"
   fi
-  echo "removing existing symlink: $target -> $current"
-  rm "$target"
-elif [[ -e "$target" ]]; then
-  ts=$(date +%s)
-  backup="${target}.bak-${ts}"
-  mv "$target" "$backup"
-  echo "backed up real install to: $backup"
+
+  if ln -s "$source" "$target"; then
+    echo "linked: $target -> $source"
+    return 0
+  else
+    echo "error: failed to symlink $target -> $source" >&2
+    return 1
+  fi
+}
+
+cache_target=$(compute_target_path)
+legacy_target=$(compute_legacy_target_path)
+legacy_source="${repo_root}/skills/$(basename "$legacy_target")"
+
+exit_code=0
+link_one "$cache_target" "$repo_root" || exit_code=1
+link_one "$legacy_target" "$legacy_source" || exit_code=1
+
+if [[ "$exit_code" -eq 0 ]]; then
+  echo "restart Claude Code (or /plugin reload) to pick up changes if needed"
 fi
 
-ln -s "$repo_root" "$target"
-echo "linked: $target -> $repo_root"
-echo "restart Claude Code (or /plugin reload) to pick up changes if needed"
+exit "$exit_code"

--- a/scripts/dev/lint.sh
+++ b/scripts/dev/lint.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+failures=0
+
+# Check 1: shellcheck
+printf '==> shellcheck\n'
+if ! command -v shellcheck >/dev/null 2>&1; then
+  printf 'WARN: shellcheck not installed; skipping shell lint. brew install shellcheck\n'
+else
+  shellcheck_ok=1
+  for dir in "$REPO_ROOT/skills/cmux-tab-agents/scripts" "$REPO_ROOT/scripts/dev"; do
+    if [[ -d "$dir" ]]; then
+      while IFS= read -r f; do
+        if ! shellcheck "$f"; then
+          shellcheck_ok=0
+        fi
+      done < <(find "$dir" -name '*.sh' -type f 2>/dev/null | sort)
+    fi
+  done
+  if [[ "$shellcheck_ok" -eq 1 ]]; then
+    printf 'OK\n'
+  else
+    failures=$((failures + 1))
+  fi
+fi
+
+# Check 2: JSON validation
+printf '==> json-validation\n'
+json_ok=1
+for f in "$REPO_ROOT/.claude-plugin/plugin.json" "$REPO_ROOT/.claude-plugin/marketplace.json"; do
+  if ! jq empty "$f" 2>/dev/null; then
+    printf 'FAIL: %s\n' "$f"
+    json_ok=0
+  fi
+done
+if [[ "$json_ok" -eq 1 ]]; then
+  printf 'OK\n'
+else
+  failures=$((failures + 1))
+fi
+
+# Check 3: prompt-template lint
+printf '==> prompt-template-lint\n'
+prompt_ok=1
+for phase in implementer spec-reviewer code-reviewer; do
+  if ! bash "$SCRIPT_DIR/render-prompt.sh" "$phase" --check; then
+    prompt_ok=0
+  fi
+done
+if [[ "$prompt_ok" -eq 1 ]]; then
+  printf 'OK\n'
+else
+  failures=$((failures + 1))
+fi
+
+printf '\nlint: 3 checks ran, %d failures\n' "$failures"
+if [[ "$failures" -gt 0 ]]; then
+  exit 1
+fi

--- a/scripts/dev/render-prompt.sh
+++ b/scripts/dev/render-prompt.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# Canonical allowlist — must match _dispatch_common.sh render_template mapping.
+# PLANNER_SURFACE included for forward compatibility (not yet handled in dispatch).
+ALLOWLIST="TICKET TITLE SLUG WORKTREE PLANNER_WORKSPACE PLANNER_SURFACE TASK IMPLEMENTER_SHA FEEDBACK"
+
+# Sample defaults used when --values does not override a key.
+_DEF_TICKET="ALPM-DEV-1"
+_DEF_TITLE="sample title"
+_DEF_SLUG="sample-slug"
+_DEF_WORKTREE="/tmp/sample-worktree"
+_DEF_PLANNER_WORKSPACE="workspace:99"
+_DEF_PLANNER_SURFACE="surface:99"
+_DEF_IMPLEMENTER_SHA="deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+# TASK and FEEDBACK go through env to sidestep quoting issues with multiline text.
+_DEF_TASK='Sample task body. Replace via --values TASK="...".'
+_DEF_FEEDBACK=""
+
+PHASE=""
+CHECK=0
+VALUES=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --check)
+      CHECK=1; shift ;;
+    --values)
+      if [[ $# -lt 2 ]]; then
+        echo "render-prompt.sh: --values requires an argument" >&2; exit 1
+      fi
+      VALUES="$2"; shift 2 ;;
+    -*)
+      echo "render-prompt.sh: unknown option '$1'" >&2; exit 1 ;;
+    *)
+      if [[ -z "$PHASE" ]]; then
+        PHASE="$1"
+      else
+        echo "render-prompt.sh: unexpected argument '$1'" >&2; exit 1
+      fi
+      shift ;;
+  esac
+done
+
+if [[ -z "$PHASE" ]]; then
+  printf 'Usage: render-prompt.sh <implementer|spec-reviewer|code-reviewer> [--values KEY=VAL,...] [--check]\n' >&2
+  exit 1
+fi
+
+case "$PHASE" in
+  implementer|spec-reviewer|code-reviewer) ;;
+  *)
+    echo "render-prompt.sh: invalid phase '$PHASE' (valid: implementer, spec-reviewer, code-reviewer)" >&2
+    exit 1 ;;
+esac
+
+TEMPLATE="$REPO_ROOT/skills/cmux-tab-agents/prompts/${PHASE}-tab-prompt.md"
+if [[ ! -r "$TEMPLATE" ]]; then
+  echo "render-prompt.sh: template not found: $TEMPLATE" >&2
+  exit 1
+fi
+
+_RENDER_TASK="$_DEF_TASK" \
+_RENDER_FEEDBACK="$_DEF_FEEDBACK" \
+python3 - "$TEMPLATE" "$ALLOWLIST" "$VALUES" "$PHASE" "$CHECK" \
+          "$_DEF_TICKET" "$_DEF_TITLE" "$_DEF_SLUG" "$_DEF_WORKTREE" \
+          "$_DEF_PLANNER_WORKSPACE" "$_DEF_PLANNER_SURFACE" "$_DEF_IMPLEMENTER_SHA" <<'PY'
+import sys, re, os
+
+template_path  = sys.argv[1]
+allowlist      = sys.argv[2].split()
+values_str     = sys.argv[3]
+phase          = sys.argv[4]
+check_mode     = sys.argv[5] == "1"
+
+defaults = {
+    "TICKET":            sys.argv[6],
+    "TITLE":             sys.argv[7],
+    "SLUG":              sys.argv[8],
+    "WORKTREE":          sys.argv[9],
+    "PLANNER_WORKSPACE": sys.argv[10],
+    "PLANNER_SURFACE":   sys.argv[11],
+    "IMPLEMENTER_SHA":   sys.argv[12],
+    "TASK":              os.environ.get("_RENDER_TASK", ""),
+    "FEEDBACK":          os.environ.get("_RENDER_FEEDBACK", ""),
+}
+
+overrides = {}
+if values_str:
+    for pair in values_str.split(","):
+        eq = pair.find("=")
+        if eq == -1:
+            print("render-prompt.sh: malformed --values pair (no '='): " + repr(pair), file=sys.stderr)
+            sys.exit(1)
+        k, v = pair[:eq], pair[eq+1:]
+        overrides[k] = v
+
+mapping = {**defaults, **overrides}
+
+with open(template_path, "r", encoding="utf-8") as f:
+    body = f.read()
+
+if check_mode:
+    all_tokens = re.findall(r'{{(.*?)}}', body, re.DOTALL)
+    bad_shape = [t for t in all_tokens if not re.match(r'^[A-Z_]+$', t)]
+    if bad_shape:
+        for t in bad_shape:
+            print("error: malformed token {{" + t + "}} in " + template_path + " (must be {{[A-Z_]+}}-shaped)", file=sys.stderr)
+        sys.exit(1)
+    orphans = sorted(set(t for t in all_tokens if t not in allowlist))
+    if orphans:
+        for t in orphans:
+            print("orphan token {{" + t + "}} in " + template_path + ": not in allowlist", file=sys.stderr)
+        sys.exit(1)
+    print("OK: " + phase + " template clean")
+else:
+    for k, v in mapping.items():
+        body = body.replace("{{" + k + "}}", v)
+    sys.stdout.write(body)
+PY

--- a/scripts/dev/status.sh
+++ b/scripts/dev/status.sh
@@ -6,17 +6,30 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${script_dir}/_target-path.sh"
 
 repo_root=$(git rev-parse --show-toplevel)
-target=$(compute_target_path)
 
-if [[ -L "$target" ]]; then
-  current=$(resolve_symlink_target "$target")
-  if [[ "$current" == "$repo_root" ]]; then
-    echo "linked: $target -> $repo_root"
+# Print status for a single target linked to the given source.
+status_one() {
+  local target="$1"
+  local source="$2"
+
+  if [[ -L "$target" ]]; then
+    local current
+    current=$(resolve_symlink_target "$target")
+    if [[ "$current" == "$source" ]]; then
+      echo "linked: $target -> $source"
+    else
+      echo "linked elsewhere: $target -> $current"
+    fi
+  elif [[ -d "$target" ]]; then
+    echo "installed (not linked): $target"
   else
-    echo "linked elsewhere: $target -> $current"
+    echo "not installed: $target"
   fi
-elif [[ -d "$target" ]]; then
-  echo "installed (not linked): $target"
-else
-  echo "not installed"
-fi
+}
+
+cache_target=$(compute_target_path)
+legacy_target=$(compute_legacy_target_path)
+legacy_source="${repo_root}/skills/$(basename "$legacy_target")"
+
+status_one "$cache_target" "$repo_root"
+status_one "$legacy_target" "$legacy_source"

--- a/scripts/dev/status.sh
+++ b/scripts/dev/status.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=_target-path.sh
+source "${script_dir}/_target-path.sh"
+
+repo_root=$(git rev-parse --show-toplevel)
+target=$(compute_target_path)
+
+if [[ -L "$target" ]]; then
+  current=$(resolve_symlink_target "$target")
+  if [[ "$current" == "$repo_root" ]]; then
+    echo "linked: $target -> $repo_root"
+  else
+    echo "linked elsewhere: $target -> $current"
+  fi
+elif [[ -d "$target" ]]; then
+  echo "installed (not linked): $target"
+else
+  echo "not installed"
+fi

--- a/scripts/dev/tests/test_acceptance.sh
+++ b/scripts/dev/tests/test_acceptance.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Acceptance tests for CTADEV-2: render-prompt.sh and lint.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+RENDER="$REPO_ROOT/scripts/dev/render-prompt.sh"
+LINT="$REPO_ROOT/scripts/dev/lint.sh"
+
+PASS=0
+FAIL=0
+
+pass() { printf 'PASS: %s\n' "$1"; PASS=$((PASS+1)); }
+fail() { printf 'FAIL: %s\n' "$1"; FAIL=$((FAIL+1)); }
+
+check_exit_zero() {
+  local label="$1"; shift
+  if "$@" >/dev/null 2>&1; then pass "$label"
+  else fail "$label (expected exit 0)"; fi
+}
+
+check_exit_nonzero() {
+  local label="$1"; shift
+  if ! "$@" >/dev/null 2>&1; then pass "$label"
+  else fail "$label (expected non-zero exit)"; fi
+}
+
+check_output_contains() {
+  local label="$1" expected="$2"; shift 2
+  local out
+  out="$("$@" 2>&1)" || true
+  if printf '%s' "$out" | grep -qF "$expected"; then pass "$label"
+  else fail "$label -- expected '${expected}' in: ${out:0:120}"; fi
+}
+
+check_output_not_contains() {
+  local label="$1" unexpected="$2"; shift 2
+  local out
+  out="$("$@" 2>&1)" || true
+  if ! printf '%s' "$out" | grep -qF "$unexpected"; then pass "$label"
+  else fail "$label -- unexpected '${unexpected}' found in output"; fi
+}
+
+printf '=== CTADEV-2 acceptance tests ===\n\n'
+
+# T1: bash syntax check
+check_exit_zero "bash -n render-prompt.sh" bash -n "$RENDER"
+check_exit_zero "bash -n lint.sh" bash -n "$LINT"
+
+# T2: render implementer → no unsubstituted tokens for known keys
+check_output_not_contains "render implementer: no {{TICKET}}" "{{TICKET}}" bash "$RENDER" implementer
+check_output_not_contains "render implementer: no {{TASK}}" "{{TASK}}" bash "$RENDER" implementer
+check_output_not_contains "render implementer: no {{WORKTREE}}" "{{WORKTREE}}" bash "$RENDER" implementer
+check_output_not_contains "render implementer: no {{PLANNER_WORKSPACE}}" "{{PLANNER_WORKSPACE}}" bash "$RENDER" implementer
+check_output_not_contains "render implementer: no {{PLANNER_SURFACE}}" "{{PLANNER_SURFACE}}" bash "$RENDER" implementer
+check_output_not_contains "render implementer: no {{FEEDBACK}}" "{{FEEDBACK}}" bash "$RENDER" implementer
+
+# T3: --check mode exits 0 for all phases
+check_exit_zero "render implementer --check exits 0" bash "$RENDER" implementer --check
+check_exit_zero "render spec-reviewer --check exits 0" bash "$RENDER" spec-reviewer --check
+check_exit_zero "render code-reviewer --check exits 0" bash "$RENDER" code-reviewer --check
+
+# T4: --check mode prints OK message
+check_output_contains "render implementer --check: OK message" \
+  "OK: implementer template clean" bash "$RENDER" implementer --check
+
+# T5: --values overrides applied in rendered output
+out=$(bash "$RENDER" spec-reviewer --values "TICKET=TEST-1,TASK=dummy" 2>&1) || out=""
+if printf '%s' "$out" | grep -qF "TEST-1"; then pass "render spec-reviewer: TICKET override"
+else fail "render spec-reviewer: TICKET override not found in output"; fi
+if printf '%s' "$out" | grep -qF "dummy"; then pass "render spec-reviewer: TASK override"
+else fail "render spec-reviewer: TASK override not found in output"; fi
+
+# T6: invalid phase exits non-zero
+check_exit_nonzero "invalid phase exits non-zero" bash "$RENDER" bad-phase
+
+# T7: missing phase exits non-zero with error message
+check_output_contains "bad-phase: error on stderr" "invalid phase" bash "$RENDER" bad-phase 2>&1 || true
+check_exit_nonzero "bad-phase exits non-zero" bash "$RENDER" bad-phase
+
+# T8: make preview exits 0
+check_exit_zero "make preview exits 0" make -C "$REPO_ROOT" preview
+
+# T10: make lint exits 0
+check_exit_zero "make lint exits 0" make -C "$REPO_ROOT" lint
+
+# T11: make help lists all 6 targets
+out=$(make -C "$REPO_ROOT" help 2>&1) || out=""
+for target in help link unlink status lint preview; do
+  if printf '%s' "$out" | grep -qF "$target"; then pass "make help lists '$target'"
+  else fail "make help missing '$target'"; fi
+done
+
+printf '\n=== Results: %d passed, %d failed ===\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/scripts/dev/tests/test_target_path.sh
+++ b/scripts/dev/tests/test_target_path.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Tests for _target-path.sh — CTADEV-10 refactor
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+TARGET_PATH_SH="$REPO_ROOT/scripts/dev/_target-path.sh"
+
+PASS=0
+FAIL=0
+
+pass() { printf 'PASS: %s\n' "$1"; PASS=$((PASS+1)); }
+fail() { printf 'FAIL: %s\n' "$1"; FAIL=$((FAIL+1)); }
+
+printf '=== CTADEV-10 _target-path.sh tests ===\n\n'
+
+# T1: bash syntax check
+if bash -n "$TARGET_PATH_SH" 2>/dev/null; then pass "bash -n _target-path.sh"
+else fail "bash -n _target-path.sh (syntax error)"; fi
+
+# T2: _read_manifest_fields exists after sourcing
+out=$(bash -c ". '$TARGET_PATH_SH'; declare -f _read_manifest_fields" 2>&1)
+if printf '%s' "$out" | grep -q '_read_manifest_fields'; then pass "_read_manifest_fields is defined"
+else fail "_read_manifest_fields not defined after sourcing"; fi
+
+# T3: _read_manifest_fields echoes name and version (space-separated)
+out=$(cd "$REPO_ROOT" && bash -c ". '$TARGET_PATH_SH'; _read_manifest_fields" 2>&1)
+manifest="$REPO_ROOT/.claude-plugin/plugin.json"
+expected_name=$(jq -r '.name' "$manifest" 2>/dev/null)
+expected_version=$(jq -r '.version' "$manifest" 2>/dev/null)
+if printf '%s' "$out" | grep -qF "${expected_name} ${expected_version}"; then
+  pass "_read_manifest_fields returns 'name version'"
+else
+  fail "_read_manifest_fields: expected '${expected_name} ${expected_version}', got: ${out}"; fi
+
+# T4: compute_target_path still produces a path containing name and version
+out=$(cd "$REPO_ROOT" && bash -c ". '$TARGET_PATH_SH'; compute_target_path" 2>&1)
+if printf '%s' "$out" | grep -qF "$expected_name" && printf '%s' "$out" | grep -qF "$expected_version"; then
+  pass "compute_target_path output contains name and version"
+else
+  fail "compute_target_path output: $out"; fi
+
+# T5: compute_legacy_target_path still produces ~/.claude/skills/<name>
+out=$(cd "$REPO_ROOT" && bash -c ". '$TARGET_PATH_SH'; compute_legacy_target_path" 2>&1)
+expected_legacy="${HOME}/.claude/skills/${expected_name}"
+if [[ "$out" == "$expected_legacy" ]]; then pass "compute_legacy_target_path returns correct path"
+else fail "compute_legacy_target_path: expected '$expected_legacy', got '$out'"; fi
+
+# T6: _read_manifest_fields fails with error when run outside a git repo
+tmpdir=$(mktemp -d)
+out=$(cd "$tmpdir" && bash -c ". '$TARGET_PATH_SH'; _read_manifest_fields" 2>&1); rc=$?
+rm -rf "$tmpdir"
+if [[ $rc -ne 0 ]] && printf '%s' "$out" | grep -q "not inside a git repository"; then
+  pass "_read_manifest_fields: error outside git repo"
+else
+  fail "_read_manifest_fields: expected git-repo error, got rc=$rc out=$out"; fi
+
+printf '\n=== Results: %d passed, %d failed ===\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/scripts/dev/unlink.sh
+++ b/scripts/dev/unlink.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=_target-path.sh
+source "${script_dir}/_target-path.sh"
+
+repo_root=$(git rev-parse --show-toplevel)
+target=$(compute_target_path)
+
+if [[ ! -e "$target" && ! -L "$target" ]]; then
+  echo "not linked"
+  exit 0
+fi
+
+if [[ -L "$target" ]]; then
+  current=$(resolve_symlink_target "$target")
+  if [[ "$current" != "$repo_root" ]]; then
+    echo "warning: target is a symlink to '${current}', not this repo (${repo_root}); refusing to remove" >&2
+    exit 1
+  fi
+  rm "$target"
+  echo "unlinked: $target"
+
+  parent_dir=$(dirname "$target")
+  base=$(basename "$target")
+  shopt -s nullglob
+  backups=( "$parent_dir/$base".bak-* )
+  shopt -u nullglob
+  if [[ ${#backups[@]} -gt 0 ]]; then
+    echo "found backup(s) — restore manually if you want the previous install:"
+    for b in "${backups[@]}"; do
+      echo "  mv \"$b\" \"$target\""
+    done
+  fi
+  exit 0
+fi
+
+echo "target is not a symlink, refusing to remove: $target" >&2
+exit 1

--- a/scripts/dev/unlink.sh
+++ b/scripts/dev/unlink.sh
@@ -6,35 +6,55 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${script_dir}/_target-path.sh"
 
 repo_root=$(git rev-parse --show-toplevel)
-target=$(compute_target_path)
 
-if [[ ! -e "$target" && ! -L "$target" ]]; then
-  echo "not linked"
-  exit 0
-fi
+# Unlink a single target that was linked to the given source.
+# Prints outcome. Returns 1 on failure/warning, 0 on success.
+unlink_one() {
+  local target="$1"
+  local source="$2"
 
-if [[ -L "$target" ]]; then
-  current=$(resolve_symlink_target "$target")
-  if [[ "$current" != "$repo_root" ]]; then
-    echo "warning: target is a symlink to '${current}', not this repo (${repo_root}); refusing to remove" >&2
-    exit 1
+  if [[ ! -e "$target" && ! -L "$target" ]]; then
+    echo "not linked: $target"
+    return 0
   fi
-  rm "$target"
-  echo "unlinked: $target"
 
-  parent_dir=$(dirname "$target")
-  base=$(basename "$target")
-  shopt -s nullglob
-  backups=( "$parent_dir/$base".bak-* )
-  shopt -u nullglob
-  if [[ ${#backups[@]} -gt 0 ]]; then
-    echo "found backup(s) — restore manually if you want the previous install:"
-    for b in "${backups[@]}"; do
-      echo "  mv \"$b\" \"$target\""
-    done
+  if [[ -L "$target" ]]; then
+    local current
+    current=$(resolve_symlink_target "$target")
+    if [[ "$current" != "$source" ]]; then
+      echo "warning: $target is a symlink to '${current}', not expected source (${source}); refusing to remove" >&2
+      return 1
+    fi
+    rm "$target"
+    echo "unlinked: $target"
+
+    local parent_dir base
+    parent_dir=$(dirname "$target")
+    base=$(basename "$target")
+    shopt -s nullglob
+    local backups
+    backups=( "$parent_dir/$base".bak-* )
+    shopt -u nullglob
+    if [[ ${#backups[@]} -gt 0 ]]; then
+      echo "found backup(s) — restore manually if you want the previous install:"
+      local b
+      for b in "${backups[@]}"; do
+        echo "  mv \"$b\" \"$target\""
+      done
+    fi
+    return 0
   fi
-  exit 0
-fi
 
-echo "target is not a symlink, refusing to remove: $target" >&2
-exit 1
+  echo "warning: $target is a real directory, not a symlink; refusing to remove" >&2
+  return 1
+}
+
+cache_target=$(compute_target_path)
+legacy_target=$(compute_legacy_target_path)
+legacy_source="${repo_root}/skills/$(basename "$legacy_target")"
+
+exit_code=0
+unlink_one "$cache_target" "$repo_root" || exit_code=1
+unlink_one "$legacy_target" "$legacy_source" || exit_code=1
+
+exit "$exit_code"

--- a/skills/cmux-tab-agents/prompts/code-reviewer-tab-prompt.md
+++ b/skills/cmux-tab-agents/prompts/code-reviewer-tab-prompt.md
@@ -15,11 +15,10 @@ Your worktree is `{{WORKTREE}}`. Your planner is in cmux workspace `{{PLANNER_WO
 
 ## Boot sequence
 
-1. `cmux rename-tab "{{TICKET}}: code review"`
-2. `cmux set-status {{TICKET}}-code-reviewer "reviewing" --icon magnifyingglass --color "#007aff"`
-3. `cmux set-status {{TICKET}}-code-reviewer "reviewing" --icon magnifyingglass --color "#007aff" --workspace {{PLANNER_WORKSPACE}}`
-4. `cmux log "starting code review for {{TICKET}}" --level info`
-5. `cd {{WORKTREE}} && pwd && git log --oneline -5`
+1. `cmux set-status {{TICKET}}-code-reviewer "reviewing" --icon magnifyingglass --color "#007aff" 2>/dev/null || true`
+2. `cmux set-status {{TICKET}}-code-reviewer "reviewing" --icon magnifyingglass --color "#007aff" --workspace {{PLANNER_WORKSPACE}} 2>/dev/null || true`
+3. `cmux log "starting code review for {{TICKET}}" --level info 2>/dev/null || true`
+4. `cd {{WORKTREE}} && pwd && git log --oneline -5`
 
 ## Inputs
 
@@ -142,10 +141,9 @@ Then update cmux:
 state="<approved|issues_found>"
 icon="<checkmark|warning>"
 color="<#34c759|#ffcc00>"
-cmux set-status {{TICKET}}-code-reviewer "$state" --icon "$icon" --color "$color"
-cmux set-status {{TICKET}}-code-reviewer "$state" --icon "$icon" --color "$color" \
-  --workspace {{PLANNER_WORKSPACE}}
-cmux log "code review {{TICKET}} → $state" --level <success|warning>
+cmux set-status {{TICKET}}-code-reviewer "$state" --icon "$icon" --color "$color" 2>/dev/null || true
+cmux set-status {{TICKET}}-code-reviewer "$state" --icon "$icon" --color "$color" --workspace {{PLANNER_WORKSPACE}} 2>/dev/null || true
+cmux log "code review {{TICKET}} → $state" --level <success|warning> 2>/dev/null || true
 cmux notify --title "{{TICKET}} code review $state" \
   --body "<one-line verdict>" \
   --workspace {{PLANNER_WORKSPACE}}

--- a/skills/cmux-tab-agents/prompts/implementer-tab-prompt.md
+++ b/skills/cmux-tab-agents/prompts/implementer-tab-prompt.md
@@ -18,11 +18,10 @@ Your planner is in cmux workspace `{{PLANNER_WORKSPACE}}` at surface `{{PLANNER_
 
 In this exact order:
 
-1. `cmux rename-tab "{{TICKET}}: {{TITLE}}"`
-2. `cmux set-status {{TICKET}}-implementer "working" --icon hammer --color "#ff9500"`
-3. `cmux set-status {{TICKET}}-implementer "working" --icon hammer --color "#ff9500" --workspace {{PLANNER_WORKSPACE}}`
-4. `cmux log "starting implementer for {{TICKET}}" --level info`
-5. `cd {{WORKTREE}} && pwd && git status` — verify you are in the worktree, not the parent repo, and that the worktree is clean.
+1. `cmux set-status {{TICKET}}-implementer "working" --icon hammer --color "#ff9500" 2>/dev/null || true`
+2. `cmux set-status {{TICKET}}-implementer "working" --icon hammer --color "#ff9500" --workspace {{PLANNER_WORKSPACE}} 2>/dev/null || true`
+3. `cmux log "starting implementer for {{TICKET}}" --level info 2>/dev/null || true`
+4. `cd {{WORKTREE}} && pwd && git status` — verify you are in the worktree, not the parent repo, and that the worktree is clean.
 
 If `pwd` doesn't print `{{WORKTREE}}` exactly, STOP. Set status to `blocked` and notify the planner.
 
@@ -411,10 +410,9 @@ state="<done|done_with_concerns|blocked>"
 icon="<checkmark|warning|x>"
 color="<#34c759|#ffcc00|#ff3b30>"
 
-cmux set-status {{TICKET}}-implementer "$state" --icon "$icon" --color "$color"
-cmux set-status {{TICKET}}-implementer "$state" --icon "$icon" --color "$color" \
-  --workspace {{PLANNER_WORKSPACE}}
-cmux log "implementer {{TICKET}} → $state" --level <info|warning|error>
+cmux set-status {{TICKET}}-implementer "$state" --icon "$icon" --color "$color" 2>/dev/null || true
+cmux set-status {{TICKET}}-implementer "$state" --icon "$icon" --color "$color" --workspace {{PLANNER_WORKSPACE}} 2>/dev/null || true
+cmux log "implementer {{TICKET}} → $state" --level <info|warning|error> 2>/dev/null || true
 cmux notify --title "{{TICKET}} implementer $state" \
   --body "<one-line summary from your result file>" \
   --workspace {{PLANNER_WORKSPACE}}

--- a/skills/cmux-tab-agents/prompts/spec-reviewer-tab-prompt.md
+++ b/skills/cmux-tab-agents/prompts/spec-reviewer-tab-prompt.md
@@ -15,11 +15,10 @@ You are reviewing the implementer's work. The implementer's tab is still open in
 
 ## Boot sequence
 
-1. `cmux rename-tab "{{TICKET}}: spec review"`
-2. `cmux set-status {{TICKET}}-spec-reviewer "reviewing" --icon magnifyingglass --color "#007aff"`
-3. `cmux set-status {{TICKET}}-spec-reviewer "reviewing" --icon magnifyingglass --color "#007aff" --workspace {{PLANNER_WORKSPACE}}`
-4. `cmux log "starting spec review for {{TICKET}}" --level info`
-5. `cd {{WORKTREE}} && pwd && git log --oneline -5` — verify worktree, see recent commits.
+1. `cmux set-status {{TICKET}}-spec-reviewer "reviewing" --icon magnifyingglass --color "#007aff" 2>/dev/null || true`
+2. `cmux set-status {{TICKET}}-spec-reviewer "reviewing" --icon magnifyingglass --color "#007aff" --workspace {{PLANNER_WORKSPACE}} 2>/dev/null || true`
+3. `cmux log "starting spec review for {{TICKET}}" --level info 2>/dev/null || true`
+4. `cd {{WORKTREE}} && pwd && git log --oneline -5` — verify worktree, see recent commits.
 
 ## Inputs
 
@@ -163,10 +162,9 @@ Then update cmux:
 state="<approved|issues_found>"
 icon="<checkmark|warning>"
 color="<#34c759|#ffcc00>"
-cmux set-status {{TICKET}}-spec-reviewer "$state" --icon "$icon" --color "$color"
-cmux set-status {{TICKET}}-spec-reviewer "$state" --icon "$icon" --color "$color" \
-  --workspace {{PLANNER_WORKSPACE}}
-cmux log "spec review {{TICKET}} → $state" --level <success|warning>
+cmux set-status {{TICKET}}-spec-reviewer "$state" --icon "$icon" --color "$color" 2>/dev/null || true
+cmux set-status {{TICKET}}-spec-reviewer "$state" --icon "$icon" --color "$color" --workspace {{PLANNER_WORKSPACE}} 2>/dev/null || true
+cmux log "spec review {{TICKET}} → $state" --level <success|warning> 2>/dev/null || true
 cmux notify --title "{{TICKET}} spec review $state" \
   --body "<one-line verdict>" \
   --workspace {{PLANNER_WORKSPACE}}

--- a/skills/cmux-tab-agents/scripts/_dispatch_common.sh
+++ b/skills/cmux-tab-agents/scripts/_dispatch_common.sh
@@ -186,8 +186,12 @@ print(d.get("caller",{}).get("pane_ref") or d.get("focused",{}).get("pane_ref","
   # the trailing newline is interpreted differently.
   local model_flag=""
   [[ -n "$MODEL" ]] && model_flag=" --model $MODEL"
+  # Pass an initial user message as the trailing positional arg to claude so
+  # the agent fires immediately on boot instead of idling on the welcome
+  # screen. Avoids the fragile backgrounded `( sleep N; cmux send ... ) &`
+  # nudge that gets SIGHUP'd when the dispatcher exits.
   cmux send --surface "$SURFACE" \
-    "cd $WT && claude --dangerously-skip-permissions${model_flag} --append-system-prompt \"\$(cat $RENDERED)\""$'\n'
+    "cd $WT && claude --dangerously-skip-permissions${model_flag} --append-system-prompt \"\$(cat $RENDERED)\" \"Begin executing the task per the system prompt.\""$'\n'
   cmux send-key --surface "$SURFACE" enter >/dev/null 2>&1 || true
 
   # 5. Set initial dispatch pill on the planner's workspace.


### PR DESCRIPTION
## Summary

Adds a complete local development environment for the plugin and fixes several v0.2.0 dispatcher bugs discovered while dogfooding the plugin to build its own dev env.

8 tickets, run through the cmux-tab-agents pipeline (implementer → spec-reviewer → code-quality-reviewer per ticket). 16 commits (8 feature + 8 merge).

## What's new

**Local dev tooling (CTADEV-1, 2, 3, 8, 10, 11):**
- `Makefile` with `link / unlink / status / lint / preview / help`
- `scripts/dev/link.sh` — symlink local checkout into both `~/.claude/plugins/cache/<m>/<p>/<v>/` AND legacy `~/.claude/skills/<p>/`
- `scripts/dev/unlink.sh` — reverse, lists `.bak-<ts>` for manual restore
- `scripts/dev/status.sh` — show current state for both install paths
- `scripts/dev/_target-path.sh` — shared discovery helper (`_read_manifest_fields`)
- `scripts/dev/lint.sh` — shellcheck (warn-skip if absent) + `jq` JSON validation + prompt-template orphan-`{{}}` lint
- `scripts/dev/render-prompt.sh` — preview a rendered phase prompt with sample/custom values; `--check` mode validates `{{}}` tokens against allowlist
- `scripts/dev/tests/test_target_path.sh` + `test_acceptance.sh` — TDD harnesses
- `README.md` — new `## Local development` section
- `CONTRIBUTING.md` — PR-only flow, conventional commits, TDD discipline, no hook bypass

**Skill source fixes (CTADEV-4, 9):**
- `_dispatch_common.sh` — auto-start tab-agents by passing initial user message as trailing positional arg to `claude` (eliminates the "claude waits for user turn" idle problem)
- `prompts/{implementer,spec-reviewer,code-reviewer}-tab-prompt.md` — drop redundant/broken `cmux rename-tab` boot step (dispatcher already pre-renames), wrap `cmux set-status`/`cmux log` calls with `2>/dev/null || true` for graceful degradation on cmux builds without those subcommands

## Dogfood evidence

The plugin built its own dev environment. Every change in this PR went through implementer → spec-reviewer → code-quality-reviewer per the cmux-tab-agents skill, with TDD where applicable, real verification command re-runs, and independent hook-bypass scans by both reviewers. CTADEV-4 and CTADEV-9 fix bugs discovered live during the earlier ticket dispatches.

One ticket (CTADEV-10) merged via planner override: spec-reviewer flagged the additional `test_target_path.sh` file as out-of-spec; planner amended the spec retroactively to accept the test file as in-scope refactor regression coverage. Documented in the merge commit.

## Test plan

- [ ] `make help` lists all 6 targets
- [ ] `make status` reports both install paths
- [ ] `make link` symlinks both paths (cache + legacy); `make link` again is idempotent
- [ ] `make lint` exits 0 (shellcheck skipped if not installed; jq + prompt-template lint pass)
- [ ] `make preview` shows a rendered implementer prompt with sample values
- [ ] Dispatch a real ticket via `/cmux-tab-agents` — the tab-agent should auto-start and push back on terminal state
- [ ] `make unlink` reverses both symlinks; `.bak-<ts>` restoration documented

## Branch protection note

`main` is now branch-protected (PR required, no force-push, no delete, 0 approvals required). This is the first PR through the new flow.