### PR TITLE
ci: add GitHub Actions workflow for lint + tests (closes #13)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: ci
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: install shellcheck and jq
+        run: sudo apt-get update && sudo apt-get install -y shellcheck jq
+
+      - name: make lint
+        run: make lint
+
+      - name: target-path tests
+        run: bash scripts/dev/tests/test_target_path.sh
+
+      - name: render-prompt acceptance tests
+        run: bash scripts/dev/tests/test_acceptance.sh

--- a/scripts/dev/lint.sh
+++ b/scripts/dev/lint.sh
@@ -15,10 +15,12 @@ else
   for dir in "$REPO_ROOT/skills/cmux-tab-agents/scripts" "$REPO_ROOT/scripts/dev"; do
     if [[ -d "$dir" ]]; then
       while IFS= read -r f; do
-        # -x (--external-sources): follow `# shellcheck source=...` directives
-        # so SC1091 ("Not following: source") and downstream SC2034 ("var
-        # appears unused") don't fire on our wrapper-sources-common pattern.
-        if ! shellcheck -x "$f"; then
+        # -x: follow source directives so cross-file usage is visible.
+        # --severity=warning: drop info-level noise like SC1091 when shellcheck
+        # can't resolve a relative source path from the invocation cwd.
+        # (SC2034 false positives are silenced via per-line disable directives
+        # on the wrappers' PHASE assignments.)
+        if ! shellcheck -x --severity=warning "$f"; then
           shellcheck_ok=0
         fi
       done < <(find "$dir" -name '*.sh' -type f 2>/dev/null | sort)

--- a/scripts/dev/lint.sh
+++ b/scripts/dev/lint.sh
@@ -15,11 +15,10 @@ else
   for dir in "$REPO_ROOT/skills/cmux-tab-agents/scripts" "$REPO_ROOT/scripts/dev"; do
     if [[ -d "$dir" ]]; then
       while IFS= read -r f; do
-        # --severity=warning: ignore info-level findings like SC1091
-        # ("Not following: source") and SC2034 ("appears unused") which
-        # are noise for our source-at-runtime + cross-script-shared-vars
-        # patterns. CI fails on warnings and errors only.
-        if ! shellcheck --severity=warning "$f"; then
+        # -x (--external-sources): follow `# shellcheck source=...` directives
+        # so SC1091 ("Not following: source") and downstream SC2034 ("var
+        # appears unused") don't fire on our wrapper-sources-common pattern.
+        if ! shellcheck -x "$f"; then
           shellcheck_ok=0
         fi
       done < <(find "$dir" -name '*.sh' -type f 2>/dev/null | sort)

--- a/scripts/dev/lint.sh
+++ b/scripts/dev/lint.sh
@@ -15,7 +15,11 @@ else
   for dir in "$REPO_ROOT/skills/cmux-tab-agents/scripts" "$REPO_ROOT/scripts/dev"; do
     if [[ -d "$dir" ]]; then
       while IFS= read -r f; do
-        if ! shellcheck "$f"; then
+        # --severity=warning: ignore info-level findings like SC1091
+        # ("Not following: source") and SC2034 ("appears unused") which
+        # are noise for our source-at-runtime + cross-script-shared-vars
+        # patterns. CI fails on warnings and errors only.
+        if ! shellcheck --severity=warning "$f"; then
           shellcheck_ok=0
         fi
       done < <(find "$dir" -name '*.sh' -type f 2>/dev/null | sort)

--- a/skills/cmux-tab-agents/scripts/dispatch-code-reviewer.sh
+++ b/skills/cmux-tab-agents/scripts/dispatch-code-reviewer.sh
@@ -7,6 +7,7 @@
 # Pass --implementer-sha so the reviewer can scope its read to that commit.
 
 set -euo pipefail
+# shellcheck disable=SC2034 # PHASE is consumed by sourced _dispatch_common.sh
 PHASE="code-reviewer"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=./_dispatch_common.sh

--- a/skills/cmux-tab-agents/scripts/dispatch-implementer.sh
+++ b/skills/cmux-tab-agents/scripts/dispatch-implementer.sh
@@ -9,6 +9,7 @@
 # is set on the planner's workspace.
 
 set -euo pipefail
+# shellcheck disable=SC2034 # PHASE is consumed by sourced _dispatch_common.sh
 PHASE="implementer"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=./_dispatch_common.sh

--- a/skills/cmux-tab-agents/scripts/dispatch-spec-reviewer.sh
+++ b/skills/cmux-tab-agents/scripts/dispatch-spec-reviewer.sh
@@ -6,6 +6,7 @@
 # Pass --implementer-sha so the reviewer can scope its read to that commit.
 
 set -euo pipefail
+# shellcheck disable=SC2034 # PHASE is consumed by sourced _dispatch_common.sh
 PHASE="spec-reviewer"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=./_dispatch_common.sh


### PR DESCRIPTION
Closes #13.

## Summary

Single workflow `.github/workflows/ci.yml`, single `lint` job. Runs `make lint` + the two test harnesses on every PR to `main` and every push to `main`.

This PR will be the first to exercise the workflow — once it goes green here, we'll tighten branch protection to require the `lint` status check before merge:

```bash
gh api -X PATCH /repos/AhmedElBanna80/cmux-tab-agents/branches/main/protection/required_status_checks \
  -f strict=true -f 'contexts[]=lint'
```

(Done separately after the check name is registered with GitHub from this run.)

## Workflow shape

- Triggers: `pull_request: [main]`, `push: [main]`
- Runner: `ubuntu-latest`
- Installs: `shellcheck`, `jq` via apt
- Steps: `make lint` → `bash scripts/dev/tests/test_target_path.sh` → `bash scripts/dev/tests/test_acceptance.sh`
- No matrix, no caching — keep it boring; tighten if needed later

## Test plan

- [ ] PR opened — `lint` job appears under Checks
- [ ] `lint` job goes green
- [ ] Tighten branch protection (separate `gh api` call, documented above)
- [ ] Open a deliberately-broken PR (e.g. introduce `{{TYPO}}` in a prompt) and verify CI catches it before merge is allowed