### PR TITLE
feat(skill): poll-result.sh --summary-only default (#22)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,17 +4,27 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-### Changed
-
-- **ISSUE-17: Cache-friendly seed prompt rendering** — Restructured all tab-agent seed prompts (implementer, spec-reviewer, code-reviewer) to separate static prefix from dynamic task context tail. The static prefix (containing ~95% of the prompt text) is now byte-identical across dispatches, enabling Anthropic's 5-minute auto-cache to reuse it across multiple tab-agent spawns. This reduces token costs by caching the stable prefix once and only paying for the small task-specific tail per dispatch.
-
 ### Added
 
-- `references/prompt-rendering.md` — Documents the prompt caching contract, explaining the prefix/tail structure and rules for maintaining cacheability when editing prompts.
-- `tests/test-prompt-prefix-caching.sh` — Automated test suite verifying that:
-  - Prompt prefixes are byte-identical across dispatches with different task text
-  - No placeholders appear in the cacheable prefix region
-  - All placeholders are confined to the tail section
+- **ISSUE-17: Cache-friendly seed prompt rendering** — Restructured all tab-agent seed prompts (implementer, spec-reviewer, code-reviewer) to separate static prefix from dynamic task context tail. The static prefix (containing ~95% of the prompt text) is now byte-identical across dispatches, enabling Anthropic's 5-minute auto-cache to reuse it across multiple tab-agent spawns. This reduces token costs by caching the stable prefix once and only paying for the small task-specific tail per dispatch.
+  - `references/prompt-rendering.md` — Documents the prompt caching contract, explaining the prefix/tail structure and rules for maintaining cacheability when editing prompts.
+  - `tests/test-prompt-prefix-caching.sh` — Automated test suite verifying that:
+    - Prompt prefixes are byte-identical across dispatches with different task text
+    - No placeholders appear in the cacheable prefix region
+    - All placeholders are confined to the tail section
+- **ISSUE-22: poll-result.sh output modes** — Added output mode flags to reduce token cost during polling:
+  - `--full` flag: Restore original behavior (emit entire result file)
+  - `--frontmatter-only` flag: Emit only YAML frontmatter (cheapest read)
+  - Default mode (no flags): Emit YAML frontmatter + first 30 lines of markdown body + truncation marker if longer
+  - Updated SKILL.md with recommendations on when to use each mode
+  - Added comprehensive test suite (poll-result.test.sh) covering all three modes
+
+### Changed
+
+- **ISSUE-17: Prompt rendering** — Restructured seed prompts for cacheability across multiple tab-agent spawns
+- **ISSUE-22: poll-result.sh** — Default output is now summary-only (frontmatter + 30 body lines), reducing planner token cost during routine polling
+  - **SKILL.md**: Updated "Polling for results" section with documentation of new output modes
+  - **references/reporting-contract.md**: Added examples and recommendations for selective polling modes
 
 ### Compliance
 

--- a/skills/cmux-tab-agents/SKILL.md
+++ b/skills/cmux-tab-agents/SKILL.md
@@ -120,6 +120,12 @@ For detailed examples and all parameters, see `references/dispatch-reference.md`
 
 Phases: `implementer | spec-reviewer | code-reviewer`. Returns the result file's contents on stdout, exits 1 on timeout, exit 2 on a malformed file.
 
+**Output modes** (to reduce token cost):
+
+- Default (no flags): YAML frontmatter + first 30 lines of markdown body + truncation marker if body is longer. Use this for routine polling — you usually only need the `status:` and a summary.
+- `--full`: Emit the entire file. Use only when you need the full body (e.g., when `status: ISSUES_FOUND` and you need to read all the concerns, or when `status: BLOCKED` and the blocker description is long).
+- `--frontmatter-only`: Emit only the YAML frontmatter (cheapest read). Use only for status checks when you don't care about the body at all.
+
 Parse the `status:` field to drive next action. See `references/reporting-contract.md` for the full schema.
 
 ## How tab-agents talk to you

--- a/skills/cmux-tab-agents/references/reporting-contract.md
+++ b/skills/cmux-tab-agents/references/reporting-contract.md
@@ -172,6 +172,12 @@ Exit codes:
 - `1` — timeout reached.
 - `2` — file appeared but malformed (no `status:` field).
 
+**Output modes** (default vs. compact):
+
+- **Default** (no flags): Emits YAML frontmatter + first 30 lines of markdown body + truncation marker if body is longer. Reduces token cost during routine polling.
+- `--full`: Emits the entire file. Use when you need the full body (status is `ISSUES_FOUND`, `BLOCKED`, `DONE_WITH_CONCERNS` with important concerns, etc.).
+- `--frontmatter-only`: Emits only the YAML frontmatter (no body). Cheapest read for status-only checks.
+
 The planner parses the YAML frontmatter to decide the next action. A simple bash one-liner:
 
 ```bash
@@ -184,6 +190,19 @@ case "$STATUS" in
   BLOCKED)            echo "→ assess blocker, escalate or re-dispatch" ;;
   *)                  echo "→ unknown status, escalate" ;;
 esac
+```
+
+If the default truncation mode hides concerns you need, poll again with `--full`:
+
+```bash
+# First poll with default output
+RESULT=$(poll-result.sh --worktree "$WT" --phase implementer)
+STATUS=$(awk -F': *' '/^status:/ {print $2; exit}' <<< "$RESULT")
+
+# If you need the full body, fetch it
+if [[ "$STATUS" == "ISSUES_FOUND" ]] || [[ "$STATUS" == "BLOCKED" ]]; then
+  FULL=$(poll-result.sh --worktree "$WT" --phase implementer --full)
+fi
 ```
 
 ## Slurping all in-flight results

--- a/skills/cmux-tab-agents/scripts/poll-result.sh
+++ b/skills/cmux-tab-agents/scripts/poll-result.sh
@@ -3,10 +3,15 @@
 #
 # Usage:
 #   poll-result.sh --worktree PATH --phase PHASE [--timeout SECONDS] [--interval SECONDS]
+#                  [--full] [--frontmatter-only]
 #
 # PHASE ∈ {implementer | spec-reviewer | code-reviewer}.
 # Result files are written by the tab-agent at:
 #   $WORKTREE/.cmux-${PHASE}-result.md
+#
+# Flags:
+#   --full               Emit entire file content (default: truncate to 30 body lines)
+#   --frontmatter-only   Emit only YAML frontmatter (no body)
 #
 # Exit codes:
 #   0 = file appeared and parses (has a `status:` field). Contents printed to stdout.
@@ -19,15 +24,19 @@ WT=""
 PHASE=""
 TIMEOUT=1800
 INTERVAL=5
+FULL_OUTPUT=false
+FRONTMATTER_ONLY=false
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --worktree) WT="$2"; shift 2 ;;
-    --phase)    PHASE="$2"; shift 2 ;;
-    --timeout)  TIMEOUT="$2"; shift 2 ;;
-    --interval) INTERVAL="$2"; shift 2 ;;
+    --worktree)        WT="$2"; shift 2 ;;
+    --phase)           PHASE="$2"; shift 2 ;;
+    --timeout)         TIMEOUT="$2"; shift 2 ;;
+    --interval)        INTERVAL="$2"; shift 2 ;;
+    --full)            FULL_OUTPUT=true; shift ;;
+    --frontmatter-only) FRONTMATTER_ONLY=true; shift ;;
     -h|--help)
-      sed -n '2,18p' "$0" | sed 's/^# //;s/^#//'
+      sed -n '2,20p' "$0" | sed 's/^# //;s/^#//'
       exit 0
       ;;
     *) echo "poll-result: unknown arg '$1'" >&2; exit 1 ;;
@@ -61,4 +70,48 @@ if ! grep -qE '^status:[[:space:]]*[A-Z_]+' "$RESULT"; then
   exit 2
 fi
 
-cat "$RESULT"
+# Extract frontmatter and body
+frontmatter=""
+body=""
+in_frontmatter=false
+frontmatter_end_count=0
+
+while IFS= read -r line; do
+  if [[ "$line" == "---" ]]; then
+    frontmatter_end_count=$((frontmatter_end_count + 1))
+    if [[ $frontmatter_end_count -eq 1 ]]; then
+      in_frontmatter=true
+      frontmatter+="$line"$'\n'
+    elif [[ $frontmatter_end_count -eq 2 ]]; then
+      frontmatter+="$line"$'\n'
+      in_frontmatter=false
+      continue
+    fi
+  elif [[ $in_frontmatter == true ]]; then
+    frontmatter+="$line"$'\n'
+  elif [[ $frontmatter_end_count -eq 2 ]]; then
+    body+="$line"$'\n'
+  fi
+done < "$RESULT"
+
+# Output based on flags
+if [[ "$FRONTMATTER_ONLY" == true ]]; then
+  echo -n "$frontmatter"
+elif [[ "$FULL_OUTPUT" == true ]]; then
+  cat "$RESULT"
+else
+  # Default: frontmatter + up to 30 body lines + truncation marker if needed
+  echo -n "$frontmatter"
+
+  # Count lines in body
+  body_line_count=$(echo -n "$body" | grep -c . || true)
+
+  if [[ $body_line_count -le 30 ]]; then
+    # Body is short enough, print it all
+    echo -n "$body"
+  else
+    # Truncate: print first 30 lines + marker
+    echo "$body" | head -n 30
+    echo "… (truncated; use --full for entire body) …"
+  fi
+fi

--- a/skills/cmux-tab-agents/scripts/poll-result.test.sh
+++ b/skills/cmux-tab-agents/scripts/poll-result.test.sh
@@ -8,7 +8,7 @@ POLL_SCRIPT="$SCRIPT_DIR/poll-result.sh"
 
 # Create a temp directory for test artifacts
 TEST_DIR=$(mktemp -d)
-trap "rm -rf '$TEST_DIR'" EXIT
+trap 'rm -rf "$TEST_DIR"' EXIT
 
 # Synthetic result file: short body (< 30 lines)
 create_short_result() {

--- a/skills/cmux-tab-agents/scripts/poll-result.test.sh
+++ b/skills/cmux-tab-agents/scripts/poll-result.test.sh
@@ -1,0 +1,231 @@
+#!/usr/bin/env bash
+# Tests for poll-result.sh with --full, --frontmatter-only, and default summary modes.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+POLL_SCRIPT="$SCRIPT_DIR/poll-result.sh"
+
+# Create a temp directory for test artifacts
+TEST_DIR=$(mktemp -d)
+trap "rm -rf '$TEST_DIR'" EXIT
+
+# Synthetic result file: short body (< 30 lines)
+create_short_result() {
+  local worktree="$1"
+  mkdir -p "$worktree"
+  cat > "$worktree/.cmux-implementer-result.md" <<'EOF'
+---
+ticket: TEST-1
+phase: implementer
+status: DONE
+branch: feat/test-1
+last_commit: abc1234
+---
+## Summary
+This is a short result with minimal body.
+
+## Tests
+All tests pass.
+EOF
+}
+
+# Synthetic result file: long body (> 30 lines, should be truncated in summary mode)
+create_long_result() {
+  local worktree="$1"
+  mkdir -p "$worktree"
+  cat > "$worktree/.cmux-implementer-result.md" <<'EOF'
+---
+ticket: TEST-2
+phase: implementer
+status: DONE_WITH_CONCERNS
+branch: feat/test-2
+last_commit: def5678
+---
+## Summary
+This is a long result with a substantial body.
+
+## Tests
+All tests pass.
+
+## Files changed
+- src/file1.ts
+- src/file2.ts
+
+## Self-review findings
+- Finding 1
+- Finding 2
+- Finding 3
+- Finding 4
+- Finding 5
+- Finding 6
+- Finding 7
+- Finding 8
+- Finding 9
+- Finding 10
+- Finding 11
+- Finding 12
+- Finding 13
+- Finding 14
+- Finding 15
+- Finding 16
+- Finding 17
+- Finding 18
+- Finding 19
+- Finding 20
+- Finding 21
+- Finding 22
+- Finding 23
+- Finding 24
+- Finding 25
+- Finding 26
+
+## Concerns
+This is still longer.
+EOF
+}
+
+# Test 1: Default mode with short result (no truncation needed)
+test_default_short_result() {
+  local wt="$TEST_DIR/test1"
+  create_short_result "$wt"
+
+  local output
+  output=$("$POLL_SCRIPT" --worktree "$wt" --phase implementer)
+  local exit_code=$?
+
+  # Exit code should be 0
+  [[ $exit_code -eq 0 ]] || { echo "FAIL: default short — exit code $exit_code"; return 1; }
+
+  # Output should contain frontmatter
+  grep -q "^status: DONE" <<< "$output" || { echo "FAIL: default short — missing status"; return 1; }
+
+  # Output should contain body
+  grep -q "This is a short result" <<< "$output" || { echo "FAIL: default short — missing body"; return 1; }
+
+  # Output should NOT contain truncation marker
+  grep -q "… (truncated" <<< "$output" && { echo "FAIL: default short — unexpected truncation marker"; return 1; }
+
+  echo "PASS: default mode with short result"
+}
+
+# Test 2: Default mode with long result (should truncate)
+test_default_long_result() {
+  local wt="$TEST_DIR/test2"
+  create_long_result "$wt"
+
+  local output
+  output=$("$POLL_SCRIPT" --worktree "$wt" --phase implementer)
+  local exit_code=$?
+
+  # Exit code should be 0
+  [[ $exit_code -eq 0 ]] || { echo "FAIL: default long — exit code $exit_code"; return 1; }
+
+  # Output should contain frontmatter
+  grep -q "^status: DONE_WITH_CONCERNS" <<< "$output" || { echo "FAIL: default long — missing status"; return 1; }
+
+  # Output should contain some body (at least Summary section)
+  grep -q "## Summary" <<< "$output" || { echo "FAIL: default long — missing Summary section"; return 1; }
+
+  # Output should contain truncation marker
+  grep -q "… (truncated" <<< "$output" || { echo "FAIL: default long — missing truncation marker"; return 1; }
+
+  # Output should NOT be the full file (not contain the 26th finding)
+  grep -q "Finding 26" <<< "$output" && { echo "FAIL: default long — full body not truncated"; return 1; }
+
+  # Output should be roughly 30 body lines + frontmatter + marker
+  local body_line_count
+  body_line_count=$(awk '/^---$/{c++; if(c==2) start=1; next} start {print}' <<< "$output" | wc -l)
+  [[ $body_line_count -le 35 ]] || { echo "FAIL: default long — body has too many lines ($body_line_count)"; return 1; }
+
+  echo "PASS: default mode with long result (truncated)"
+}
+
+# Test 3: --full flag with long result (should NOT truncate)
+test_full_long_result() {
+  local wt="$TEST_DIR/test3"
+  create_long_result "$wt"
+
+  local output
+  output=$("$POLL_SCRIPT" --worktree "$wt" --phase implementer --full)
+  local exit_code=$?
+
+  # Exit code should be 0
+  [[ $exit_code -eq 0 ]] || { echo "FAIL: --full long — exit code $exit_code"; return 1; }
+
+  # Output should contain frontmatter
+  grep -q "^status: DONE_WITH_CONCERNS" <<< "$output" || { echo "FAIL: --full long — missing status"; return 1; }
+
+  # Output SHOULD contain the full body including later findings
+  grep -q "Finding 26" <<< "$output" || { echo "FAIL: --full long — missing full body"; return 1; }
+
+  # Output should NOT contain truncation marker
+  grep -q "… (truncated" <<< "$output" && { echo "FAIL: --full long — unexpected truncation marker"; return 1; }
+
+  echo "PASS: --full mode with long result (no truncation)"
+}
+
+# Test 4: --frontmatter-only flag (should only emit YAML)
+test_frontmatter_only() {
+  local wt="$TEST_DIR/test4"
+  create_long_result "$wt"
+
+  local output
+  output=$("$POLL_SCRIPT" --worktree "$wt" --phase implementer --frontmatter-only)
+  local exit_code=$?
+
+  # Exit code should be 0
+  [[ $exit_code -eq 0 ]] || { echo "FAIL: --frontmatter-only — exit code $exit_code"; return 1; }
+
+  # Output should contain frontmatter
+  grep -q "^status: DONE_WITH_CONCERNS" <<< "$output" || { echo "FAIL: --frontmatter-only — missing status"; return 1; }
+
+  # Output should NOT contain any markdown body
+  grep -q "## Summary" <<< "$output" && { echo "FAIL: --frontmatter-only — body present"; return 1; }
+  grep -q "This is a long result" <<< "$output" && { echo "FAIL: --frontmatter-only — body present"; return 1; }
+
+  # Output should be just the YAML block
+  local line_count
+  line_count=$(echo "$output" | wc -l)
+  [[ $line_count -le 10 ]] || { echo "FAIL: --frontmatter-only — too many lines ($line_count)"; return 1; }
+
+  echo "PASS: --frontmatter-only mode (YAML only)"
+}
+
+# Test 5: Exit codes unchanged (timeout, malformed)
+test_exit_codes() {
+  local wt="$TEST_DIR/test5"
+  mkdir -p "$wt"
+
+  # Timeout test: should exit 1 (let script timeout naturally with short timeout)
+  "$POLL_SCRIPT" --worktree "$wt" --phase implementer --timeout 1 --interval 1 2>/dev/null || {
+    local exit_code=$?
+    [[ $exit_code -eq 1 ]] || { echo "FAIL: timeout exit code is $exit_code, expected 1"; return 1; }
+  }
+
+  # Malformed file test: should exit 2
+  cat > "$wt/.cmux-implementer-result.md" <<'EOF'
+---
+ticket: TEST-6
+phase: implementer
+---
+Some body without status field
+EOF
+  "$POLL_SCRIPT" --worktree "$wt" --phase implementer 2>/dev/null || {
+    local exit_code=$?
+    [[ $exit_code -eq 2 ]] || { echo "FAIL: malformed exit code is $exit_code, expected 2"; return 1; }
+  }
+
+  echo "PASS: exit codes unchanged"
+}
+
+# Run all tests
+echo "Running poll-result.sh tests..."
+test_default_short_result
+test_default_long_result
+test_full_long_result
+test_frontmatter_only
+test_exit_codes
+
+echo ""
+echo "All tests passed!"


### PR DESCRIPTION
## Summary

Make \`poll-result.sh\` emit a compact summary by default (frontmatter + first 30 body lines + truncation marker). Adds:

- \`--full\` — restore today's behavior (full body)
- \`--frontmatter-only\` — cheapest possible read (YAML only)

Reduces planner token cost on every poll.

Closes #22

## Test plan
- [ ] CI green
- [ ] \`scripts/poll-result.test.sh\` — all 5 modes pass
- [ ] Exit codes unchanged (1 timeout, 2 malformed)

🤖 Generated with cmux-tab-agents