### PR TITLE
fix(ISSUE-25): resolve discipline.md path for use outside cmux-tab-agents repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **SKILL.md**: Updated "Polling for results" section with documentation of new output modes
   - **references/reporting-contract.md**: Added examples and recommendations for selective polling modes
 
+### Fixed
+
+- **ISSUE-25: Discipline path resolution outside cmux-tab-agents repo** — Added `{{SKILL_BASE}}` placeholder that resolves to the installed skill directory. All seed prompts now read discipline.md from `{{SKILL_BASE}}/references/discipline.md` instead of `{{WORKTREE}}/skills/cmux-tab-agents/references/discipline.md`, so the path works when the skill is used from consumer repos where `skills/cmux-tab-agents/` doesn't exist.
+  - `scripts/_dispatch_common.sh`: Computes `SKILL_BASE` from `SKILL_ROOT` and exports it to template substitution
+  - `scripts/dev/render-prompt.sh`: Added `SKILL_BASE` to allowlist and computed default value
+  - All four seed prompts updated to use `{{SKILL_BASE}}/references/discipline.md`
+  - `references/prompt-rendering.md`: Documented `{{SKILL_BASE}}` and the distinction from `{{WORKTREE}}`
+  - New test suite `scripts/dev/tests/test_skill_base_discipline_path.sh` validates discipline path resolution
+
 ### Compliance
 
 All acceptance criteria from ISSUE-17 are met:

--- a/scripts/dev/render-prompt.sh
+++ b/scripts/dev/render-prompt.sh
@@ -6,7 +6,7 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
 # Canonical allowlist — must match _dispatch_common.sh render_template mapping.
 # PLANNER_SURFACE included for forward compatibility (not yet handled in dispatch).
-ALLOWLIST="TICKET TITLE SLUG WORKTREE PLANNER_WORKSPACE PLANNER_SURFACE TASK IMPLEMENTER_SHA FEEDBACK"
+ALLOWLIST="TICKET TITLE SLUG WORKTREE PLANNER_WORKSPACE PLANNER_SURFACE TASK IMPLEMENTER_SHA FEEDBACK SKILL_BASE"
 
 # Sample defaults used when --values does not override a key.
 _DEF_TICKET="ALPM-DEV-1"
@@ -16,6 +16,7 @@ _DEF_WORKTREE="/tmp/sample-worktree"
 _DEF_PLANNER_WORKSPACE="workspace:99"
 _DEF_PLANNER_SURFACE="surface:99"
 _DEF_IMPLEMENTER_SHA="deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+_DEF_SKILL_BASE="$REPO_ROOT/skills/cmux-tab-agents"
 # TASK and FEEDBACK go through env to sidestep quoting issues with multiline text.
 _DEF_TASK='Sample task body. Replace via --values TASK="...".'
 _DEF_FEEDBACK=""
@@ -67,7 +68,7 @@ _RENDER_TASK="$_DEF_TASK" \
 _RENDER_FEEDBACK="$_DEF_FEEDBACK" \
 python3 - "$TEMPLATE" "$ALLOWLIST" "$VALUES" "$PHASE" "$CHECK" \
           "$_DEF_TICKET" "$_DEF_TITLE" "$_DEF_SLUG" "$_DEF_WORKTREE" \
-          "$_DEF_PLANNER_WORKSPACE" "$_DEF_PLANNER_SURFACE" "$_DEF_IMPLEMENTER_SHA" <<'PY'
+          "$_DEF_PLANNER_WORKSPACE" "$_DEF_PLANNER_SURFACE" "$_DEF_IMPLEMENTER_SHA" "$_DEF_SKILL_BASE" <<'PY'
 import sys, re, os
 
 template_path  = sys.argv[1]
@@ -84,6 +85,7 @@ defaults = {
     "PLANNER_WORKSPACE": sys.argv[10],
     "PLANNER_SURFACE":   sys.argv[11],
     "IMPLEMENTER_SHA":   sys.argv[12],
+    "SKILL_BASE":        sys.argv[13],
     "TASK":              os.environ.get("_RENDER_TASK", ""),
     "FEEDBACK":          os.environ.get("_RENDER_FEEDBACK", ""),
 }

--- a/scripts/dev/tests/test_skill_base_discipline_path.sh
+++ b/scripts/dev/tests/test_skill_base_discipline_path.sh
@@ -5,8 +5,6 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 RENDER="$REPO_ROOT/scripts/dev/render-prompt.sh"
-SKILL_BASE="$REPO_ROOT/skills/cmux-tab-agents"
-
 PASS=0
 FAIL=0
 

--- a/scripts/dev/tests/test_skill_base_discipline_path.sh
+++ b/scripts/dev/tests/test_skill_base_discipline_path.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Test that {{SKILL_BASE}} substitution resolves discipline.md path correctly
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+RENDER="$REPO_ROOT/scripts/dev/render-prompt.sh"
+SKILL_BASE="$REPO_ROOT/skills/cmux-tab-agents"
+
+PASS=0
+FAIL=0
+
+pass() { printf 'PASS: %s\n' "$1"; PASS=$((PASS+1)); }
+fail() { printf 'FAIL: %s\n' "$1"; FAIL=$((FAIL+1)); }
+
+# Test: rendered prompt contains a valid discipline.md path
+# Extract the path referenced in the rendered prompt and verify it exists
+test_discipline_path_exists() {
+  local phase="$1"
+
+  # Render the prompt with sample values
+  local rendered
+  rendered=$(bash "$RENDER" "$phase" 2>&1) || rendered=""
+
+  # Extract the discipline.md path from the rendered output
+  # It should be of the form: <some-path>/references/discipline.md
+  local discipline_path
+  discipline_path=$(printf '%s' "$rendered" | grep -oE '[^ `\[]*references/discipline\.md' | head -1) || discipline_path=""
+
+  if [[ -z "$discipline_path" ]]; then
+    fail "${phase}: discipline.md path not found in rendered output"
+    return 1
+  fi
+
+  # Check if the path exists on disk
+  if [[ -f "$discipline_path" ]]; then
+    pass "${phase}: discipline.md path exists at $discipline_path"
+    return 0
+  else
+    fail "${phase}: discipline.md path does not exist: $discipline_path"
+    return 1
+  fi
+}
+
+printf '=== ISSUE-25: SKILL_BASE discipline path tests ===\n\n'
+
+# Test all three phases
+for phase in implementer spec-reviewer code-reviewer; do
+  test_discipline_path_exists "$phase"
+done
+
+printf '\n=== Results: %d passed, %d failed ===\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/skills/cmux-tab-agents/prompts/code-reviewer-tab-prompt.md
+++ b/skills/cmux-tab-agents/prompts/code-reviewer-tab-prompt.md
@@ -18,7 +18,8 @@ You are the **CODE QUALITY REVIEWER** tab-agent. Task context (ticket, title, wo
 
 ## Discipline (read first)
 
-Read `<WORKTREE>/skills/cmux-tab-agents/references/discipline.md` before doing anything else (see task context for `<WORKTREE>`).
+Read `{{SKILL_BASE}}/references/discipline.md` before doing anything else.
+
 ## Boot sequence
 
 1. `cmux set-status <TICKET>-code-reviewer "reviewing" --icon magnifyingglass --color "#007aff" 2>/dev/null || true`

--- a/skills/cmux-tab-agents/prompts/implementer-fix-only-tab-prompt.md
+++ b/skills/cmux-tab-agents/prompts/implementer-fix-only-tab-prompt.md
@@ -25,7 +25,7 @@ The code in this worktree has been reviewed. Apply ONLY the fixes listed below. 
 
 ## Discipline (read this first)
 
-Read `{{WORKTREE}}/skills/cmux-tab-agents/references/discipline.md` before doing anything else. It defines the core rules:
+Read `{{SKILL_BASE}}/references/discipline.md` before doing anything else. It defines the core rules:
 
 - **TDD red-green-refactor** — watch each test fail before writing code
 - **Verification before completion** — no claims without fresh evidence

--- a/skills/cmux-tab-agents/prompts/implementer-tab-prompt.md
+++ b/skills/cmux-tab-agents/prompts/implementer-tab-prompt.md
@@ -8,8 +8,7 @@
     ~/.claude/plugins/cache/claude-plugins-official/superpowers/5.0.7/skills/verification-before-completion/SKILL.md
   plus a custom hook-bypass prohibition.
 
-  Discipline (stable, shared across all tab-agents) moved to:
-    ~/.claude/plugins/cache/cmux-tab-agents/<VERSION>/skills/cmux-tab-agents/references/discipline.md
+  Discipline (stable, shared across all tab-agents) is referenced via {{SKILL_BASE}}/references/discipline.md
   Re-sync if upstream discipline changes.
 
   CACHE-FRIENDLY STRUCTURE: This prompt is split into a static prefix (below)
@@ -25,7 +24,7 @@ You are the **IMPLEMENTER** tab-agent. Task context is in the ## Task context se
 
 ## Discipline (read this first)
 
-Read `<WORKTREE>/skills/cmux-tab-agents/references/discipline.md` before doing anything else (see Task context section below for `<WORKTREE>` value). It defines the rules you must follow:
+Read `{{SKILL_BASE}}/references/discipline.md` before doing anything else. It defines the rules you must follow:
 
 - **TDD red-green-refactor** — watch each test fail before writing code
 - **Verification before completion** — no claims without fresh evidence

--- a/skills/cmux-tab-agents/prompts/spec-reviewer-tab-prompt.md
+++ b/skills/cmux-tab-agents/prompts/spec-reviewer-tab-prompt.md
@@ -18,7 +18,7 @@ You are the **SPEC COMPLIANCE REVIEWER** tab-agent. Task context (ticket, title,
 
 ## Discipline (read first)
 
-Read `<WORKTREE>/skills/cmux-tab-agents/references/discipline.md` before doing anything else (see task context for `<WORKTREE>`).
+Read `{{SKILL_BASE}}/references/discipline.md` before doing anything else.
 
 ## Boot sequence
 

--- a/skills/cmux-tab-agents/references/prompt-rendering.md
+++ b/skills/cmux-tab-agents/references/prompt-rendering.md
@@ -18,8 +18,29 @@ Each seed prompt is split into two logical regions:
 ### Dynamic Tail (Per-Dispatch)
 
 - The `## Task context` section and everything after it
-- Contains **all** placeholder substitutions: `{{TICKET}}`, `{{TITLE}}`, `{{WORKTREE}}`, `{{PLANNER_WORKSPACE}}`, `{{PLANNER_SURFACE}}`, `{{TASK}}`, `{{FEEDBACK}}`, `{{IMPLEMENTER_SHA}}` (as relevant to the phase)
+- Contains **all** placeholder substitutions: `{{TICKET}}`, `{{TITLE}}`, `{{WORKTREE}}`, `{{PLANNER_WORKSPACE}}`, `{{PLANNER_SURFACE}}`, `{{TASK}}`, `{{FEEDBACK}}`, `{{IMPLEMENTER_SHA}}`, `{{SKILL_BASE}}` (as relevant to the phase)
 - Changes per dispatch, so this section is not cached (it's new content each time)
+
+## Placeholder Reference
+
+| Placeholder | Purpose | Value | Scope |
+|---|---|---|---|
+| `{{TICKET}}` | Issue/task ID | e.g., `ISSUE-25` | Tail only |
+| `{{TITLE}}` | Issue title | e.g., `Fix discipline path` | Tail only |
+| `{{WORKTREE}}` | Consumer repo's worktree path | e.g., `/tmp/worktree-xyz` | Tail only |
+| `{{SKILL_BASE}}` | Installed skill directory | e.g., `/home/.claude/plugins/.../skills/cmux-tab-agents` | Prefix or tail (for reading skill files) |
+| `{{PLANNER_WORKSPACE}}` | Planner's cmux workspace | e.g., `workspace:UUID` | Tail only |
+| `{{PLANNER_SURFACE}}` | Planner's cmux surface | e.g., `surface:UUID` | Tail only |
+| `{{TASK}}` | Task specification | Multi-line task text | Tail only |
+| `{{FEEDBACK}}` | Code review feedback | Multi-line feedback text | Tail only |
+| `{{IMPLEMENTER_SHA}}` | Implementer's final commit | e.g., `abc123def456` | Tail only |
+
+### Important Distinction: {{WORKTREE}} vs {{SKILL_BASE}}
+
+- **{{WORKTREE}}** = path to the consumer repo's working directory (where the implementer works)
+- **{{SKILL_BASE}}** = path to the installed skill directory (where tab-agent code and discipline.md live)
+
+These are **different paths** when the skill is used from outside the cmux-tab-agents repo itself. Never reference `{{WORKTREE}}/skills/cmux-tab-agents/...` because that path doesn't exist in consumer repos. Use `{{SKILL_BASE}}/...` to reference skill files.
 
 ## Enforcement
 

--- a/skills/cmux-tab-agents/scripts/_dispatch_common.sh
+++ b/skills/cmux-tab-agents/scripts/_dispatch_common.sh
@@ -76,7 +76,7 @@ resolve_model_for_phase() {
 # render_template <src> <dst>  — substitutes {{KEY}} placeholders from env vars.
 # Reads source path and dest path from argv. Reads template values from env
 # (TPL_TICKET, TPL_TITLE, TPL_SLUG, TPL_WORKTREE, TPL_PWS, TPL_PSURF,
-# TPL_IMPL_SHA, TPL_TASK, TPL_FEEDBACK) — passing through env avoids shell
+# TPL_IMPL_SHA, TPL_TASK, TPL_FEEDBACK, TPL_SKILL_BASE) — passing through env avoids shell
 # quoting issues with multiline task text and arbitrary review feedback.
 render_template() {
   local src="$1" dst="$2"
@@ -93,6 +93,7 @@ mapping = {
     "IMPLEMENTER_SHA":   os.environ.get("TPL_IMPL_SHA", ""),
     "TASK":              os.environ.get("TPL_TASK", ""),
     "FEEDBACK":          os.environ.get("TPL_FEEDBACK", ""),
+    "SKILL_BASE":        os.environ.get("TPL_SKILL_BASE", ""),
 }
 with open(src, "r", encoding="utf-8") as f:
     body = f.read()
@@ -265,6 +266,7 @@ print(d.get("caller",{}).get("pane_ref") or d.get("focused",{}).get("pane_ref","
   TPL_TICKET="$TICKET" TPL_TITLE="$TITLE" TPL_SLUG="$SLUG" TPL_WORKTREE="$WT" \
     TPL_PWS="$PLANNER_WS" TPL_PSURF="$PLANNER_SURFACE" \
     TPL_IMPL_SHA="$IMPL_SHA" TPL_TASK="$TASK_TEXT" TPL_FEEDBACK="$FEEDBACK" \
+    TPL_SKILL_BASE="$SKILL_ROOT" \
     render_template "$TEMPLATE" "$RENDERED"
 
   # 3. Spawn a new tab in the planner's pane. Reuse the pane ref we already


### PR DESCRIPTION
Closes #25.

## Summary

- Adds `{{SKILL_BASE}}` placeholder to `_dispatch_common.sh` — resolves to the installed skill directory at dispatch time via `dirname` chains from `$BASH_SOURCE`
- Replaces all `{{WORKTREE}}/skills/cmux-tab-agents/references/discipline.md` references in all four seed prompts with `{{SKILL_BASE}}/references/discipline.md`
- Adds `test_skill_base_discipline_path.sh` — renders a seed prompt and asserts the discipline path exists on disk after substitution
- Documents `{{SKILL_BASE}}` in `references/prompt-rendering.md` with a warning that `{{WORKTREE}}` must never be used to reach skill files

## Test plan

- [ ] CI lint passes
- [ ] CI test passes (including new `test_skill_base_discipline_path.sh`)
- [ ] Discipline path resolves correctly when skill is used from a non-cmux-tab-agents consumer repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)