### PR TITLE
feat(ISSUE-26): implementer as task lead — agent-to-agent review loop without planner

### DIFF
--- a/scripts/dev/render-prompt.sh
+++ b/scripts/dev/render-prompt.sh
@@ -6,7 +6,7 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
 # Canonical allowlist — must match _dispatch_common.sh render_template mapping.
 # PLANNER_SURFACE included for forward compatibility (not yet handled in dispatch).
-ALLOWLIST="TICKET TITLE SLUG WORKTREE PLANNER_WORKSPACE PLANNER_SURFACE TASK IMPLEMENTER_SHA FEEDBACK SKILL_BASE FINISH_MODE"
+ALLOWLIST="TICKET TITLE SLUG WORKTREE PLANNER_WORKSPACE PLANNER_SURFACE TASK IMPLEMENTER_SHA FEEDBACK SKILL_BASE FINISH_MODE LEAD_SURFACE MAX_LOOP_ITERATIONS"
 
 # Sample defaults used when --values does not override a key.
 _DEF_TICKET="ALPM-DEV-1"
@@ -20,6 +20,8 @@ _DEF_SKILL_BASE="$REPO_ROOT/skills/cmux-tab-agents"
 # TASK and FEEDBACK go through env to sidestep quoting issues with multiline text.
 _DEF_TASK='Sample task body. Replace via --values TASK="...".'
 _DEF_FEEDBACK=""
+_DEF_LEAD_SURFACE="surface:0"
+_DEF_MAX_LOOP_ITERATIONS="5"
 
 PHASE=""
 CHECK=0
@@ -69,7 +71,7 @@ _RENDER_FEEDBACK="$_DEF_FEEDBACK" \
 python3 - "$TEMPLATE" "$ALLOWLIST" "$VALUES" "$PHASE" "$CHECK" \
           "$_DEF_TICKET" "$_DEF_TITLE" "$_DEF_SLUG" "$_DEF_WORKTREE" \
           "$_DEF_PLANNER_WORKSPACE" "$_DEF_PLANNER_SURFACE" "$_DEF_IMPLEMENTER_SHA" "$_DEF_SKILL_BASE" \
-          "keep" <<'PY'
+          "keep" "$_DEF_LEAD_SURFACE" "$_DEF_MAX_LOOP_ITERATIONS" <<'PY'
 import sys, re, os
 
 template_path  = sys.argv[1]
@@ -87,9 +89,11 @@ defaults = {
     "PLANNER_SURFACE":   sys.argv[11],
     "IMPLEMENTER_SHA":   sys.argv[12],
     "SKILL_BASE":        sys.argv[13],
-    "FINISH_MODE":       sys.argv[14],
-    "TASK":              os.environ.get("_RENDER_TASK", ""),
-    "FEEDBACK":          os.environ.get("_RENDER_FEEDBACK", ""),
+    "FINISH_MODE":          sys.argv[14],
+    "LEAD_SURFACE":         sys.argv[15],
+    "MAX_LOOP_ITERATIONS":  sys.argv[16],
+    "TASK":                 os.environ.get("_RENDER_TASK", ""),
+    "FEEDBACK":             os.environ.get("_RENDER_FEEDBACK", ""),
 }
 
 overrides = {}

--- a/skills/cmux-tab-agents/CHANGELOG.md
+++ b/skills/cmux-tab-agents/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to cmux-tab-agents are documented here.
 
+## Changed
+
+- **Agent-to-agent review loop without planner involvement during iteration** (ISSUE-26): The implementer is now the **task lead** — it dispatches spec-reviewer and code-reviewer itself, loops on ISSUES_FOUND, and pushes one terminal message to the planner. New flags: `dispatch-implementer.sh --max-loop-iterations <n>` (default 5); `dispatch-spec-reviewer.sh` and `dispatch-code-reviewer.sh` accept `--lead-surface` so reviewers push ISSUES_FOUND back to the implementer and APPROVED to both implementer and planner. New `{{LEAD_SURFACE}}` and `{{MAX_LOOP_ITERATIONS}}` template placeholders in `_dispatch_common.sh`. Circuit-breaker fires on same issue twice or max iterations → BLOCKED escalation to planner. New roll-up file `.cmux-task-result.md` written by the implementer after all reviews pass. SKILL.md updated: planner dispatches `dispatch-implementer.sh` only; `dispatch-spec-reviewer.sh` and `dispatch-code-reviewer.sh` retained for manual use.
+
 ## Added
 
 - **Automated finish modes for implementer dispatch** (ISSUE-27): `dispatch-implementer.sh` now accepts `--finish-mode <mode>` to automate the post-review finish step. Modes: `keep` (default; noop), `pr` (push + open PR), `merge` (merge to main + clean). Includes `finish-task.sh` helper script with verification gate, mode-specific logic, and idempotency. See `references/finishing.md` for complete documentation, acceptance criteria compliance, and planner workflow examples.

--- a/skills/cmux-tab-agents/SKILL.md
+++ b/skills/cmux-tab-agents/SKILL.md
@@ -25,12 +25,10 @@ You are the planner. Your job is to:
 
 1. Read the plan (or the user's intent) and extract atomic sub-tasks.
 2. For each sub-task, create a Jira sub-task (or any other tracker — the skill only needs a string ID like `ALPM-1234-1`) with `parentIssueKey` pointing at the parent story.
-3. For each sub-task, dispatch an implementer tab via `dispatch-implementer.sh`, optionally with `--finish-mode <mode>` to automate the finish step.
-4. Poll each implementer's result file. Decide based on its status (DONE / DONE_WITH_CONCERNS / NEEDS_CONTEXT / BLOCKED) what to do next.
-5. After implementer reports DONE, dispatch a spec-reviewer tab. Loop reviews with the implementer if issues are found.
-6. After spec-reviewer reports APPROVED, dispatch a code-quality-reviewer tab. Loop with the implementer if issues are found.
-7. Mark the sub-task done. Move to the next.
-8. When all sub-tasks are done: if you used `--finish-mode pr` or `--finish-mode merge`, the finish step is already done. Otherwise, optionally hand off to `superpowers:finishing-a-development-branch` (which you run yourself, not in a tab).
+3. For each sub-task, dispatch an implementer tab via `dispatch-implementer.sh`, optionally with `--finish-mode <mode>` and `--max-loop-iterations <n>` to configure the task-lead pipeline.
+4. Wait for the implementer's terminal push (one line to your input box). The implementer drives the entire spec + code review loop internally.
+5. Read `.cmux-task-result.md` to confirm DONE or handle BLOCKED. Mark the sub-task done. Move to the next.
+6. When all sub-tasks are done: if you used `--finish-mode pr` or `--finish-mode merge`, the finish step is already done. Otherwise, optionally hand off to `superpowers:finishing-a-development-branch` (which you run yourself, not in a tab).
 
 **You never edit code yourself.** If you catch yourself writing files in the project, stop and dispatch instead.
 
@@ -40,56 +38,52 @@ Delegation with isolated context enables focus and fast iteration. Full wording:
 
 ## The per-task pipeline
 
+The implementer is the **task lead** — it drives the entire review loop without planner involvement during iteration. The planner dispatches one tab and receives one push per sub-task.
+
 ```
 For each sub-task (parallelizable across tasks):
   └── ensure-worktree.sh  →  worktree at <discovered base>/<TICKET>/<repo-name>
        on branch <type>/<TICKET>/<slug>  (default type: feat)
         │
-        ├── dispatch-implementer.sh      → cmux tab #1, runs claude with implementer-tab-prompt seed
-        │     │  TDD red-green-refactor, never --no-verify
-        │     │  writes .cmux-implementer-result.md, idles
-        │     ↓
-        │   Planner polls .cmux-implementer-result.md
-        │     DONE                → continue
-        │     DONE_WITH_CONCERNS  → read concerns, decide
-        │     NEEDS_CONTEXT       → re-dispatch implementer with --feedback-from-previous-review
-        │     BLOCKED             → escalate
-        │
-        ├── dispatch-spec-reviewer.sh    → cmux tab #2, same worktree, spec-reviewer-tab-prompt seed
-        │     │  reads code (NOT trusting implementer's report), re-runs verification
-        │     │  writes .cmux-spec-reviewer-result.md, idles
-        │     ↓
-        │   Planner polls .cmux-spec-reviewer-result.md
-        │     APPROVED      → continue
-        │     ISSUES_FOUND  → re-dispatch implementer with --feedback-from-previous-review,
-        │                     loop back to spec review
-        │
-        └── dispatch-code-reviewer.sh    → cmux tab #3, same worktree, code-reviewer-tab-prompt seed
-              │  reviews code quality, TDD discipline, hooks; re-runs verification
-              │  writes .cmux-code-reviewer-result.md, idles
-              ↓
-            Planner polls .cmux-code-reviewer-result.md
-              APPROVED      → mark sub-task done, move to next
-              ISSUES_FOUND  → re-dispatch implementer with --feedback-from-previous-review,
-                              loop back through spec review then code review
+        └── dispatch-implementer.sh  →  cmux tab #1, implementer-tab-prompt seed
+              │  TDD red-green-refactor, never --no-verify
+              │  After DONE, implementer spawns reviewers itself (task-lead pipeline):
+              │
+              │    dispatch-spec-reviewer.sh  (--lead-surface = implementer's own surface)
+              │      APPROVED      → implementer spawns code-reviewer
+              │      ISSUES_FOUND  → implementer fixes, re-dispatches spec-reviewer
+              │                      circuit-breaker: same issue twice or max iterations → BLOCKED
+              │
+              │    dispatch-code-reviewer.sh  (--lead-surface = implementer's own surface)
+              │      APPROVED      → implementer runs finish-task.sh, writes .cmux-task-result.md
+              │      ISSUES_FOUND  → implementer fixes, re-dispatches code-reviewer
+              │                      circuit-breaker: same issue twice or max iterations → BLOCKED
+              │
+              └── Implementer pushes ONE line to planner on terminal state:
+                    DONE:    both reviewers approved, finish-task ran
+                    BLOCKED: circuit-breaker fired or unrecoverable error
+```
+
+The planner reads `.cmux-task-result.md` (one file per sub-task, not three) to determine next steps.
+
+**Note:** `dispatch-spec-reviewer.sh` and `dispatch-code-reviewer.sh` still exist for manual planner use (e.g., re-running a review independently or when bypassing the task-lead loop). They are not called by the planner in the normal pipeline.
 
 ### Optional: Skip code-reviewer phase on trivial diffs
 
-After spec-reviewer reports `APPROVED`, the planner **MAY** skip the code-reviewer phase if the diff is trivial. See `references/skip-heuristics.md` for the heuristic (≤30 lines, test/spec/markdown/changelog files only, spec-reviewer has no concerns). Use the helper script `scripts/should-skip-code-review.sh` to make the decision deterministic:
+The implementer (as task lead) MAY skip the code-reviewer phase if the diff is trivial. See `references/skip-heuristics.md` for the heuristic (≤30 lines, test/spec/markdown/changelog files only, spec-reviewer has no concerns). Use the helper script `scripts/should-skip-code-review.sh` to make the decision deterministic:
 
 ```bash
 if ~/.claude/skills/cmux-tab-agents/scripts/should-skip-code-review.sh \
    --worktree "$WORKTREE" --implementer-sha "$(git -C $WORKTREE rev-parse HEAD)"; then
-  # → safe to skip; mark sub-task done without dispatching code-reviewer
+  # → safe to skip; write .cmux-task-result.md and push DONE to planner
 else
   # → dispatch code-reviewer as usual
 fi
 ```
 
 **Important:** Skipping is always optional. This is an optimization for small, obviously safe changes. When in doubt, run code-reviewer.
-```
 
-Three sequential tabs in the same worktree. Only one runs at a time (implementer first; reviewers run on the implementer's committed state). Tabs from prior phases stay open for inspection.
+The implementer review loop without planner involvement during iteration reduces planner context bloat and preserves the implementer's codebase context across fix rounds.
 
 ## Cross-task parallelism (override of upstream rule)
 

--- a/skills/cmux-tab-agents/prompts/code-reviewer-tab-prompt.md
+++ b/skills/cmux-tab-agents/prompts/code-reviewer-tab-prompt.md
@@ -49,14 +49,31 @@ Review for code quality. Read `git diff <base>..HEAD` and assess:
 
 Result file: `<WORKTREE>/.cmux-code-reviewer-result.md` with schema per discipline.md.
 
-Update cmux and push:
+Update cmux and push result:
+
 ```bash
-STATE="approved|issues_found"
-cmux set-status <TICKET>-code-reviewer "$STATE" --icon checkmark|warning --color "#34c759|#ffcc00" 2>/dev/null || true
-cmux send --surface "<PLANNER_SURFACE>" "[<TICKET>-code-reviewer] $STATUS: <summary>. Result: .cmux-code-reviewer-result.md"
+STATUS="APPROVED|ISSUES_FOUND"
+SUMMARY="<one-line summary>"
+
+cmux set-status <TICKET>-code-reviewer "$STATUS" --icon checkmark --color "#34c759" 2>/dev/null || true
+
+# ISSUES_FOUND → push to LEAD_SURFACE (implementer handles fixes)
+# APPROVED     → push to both lead and planner
+if [[ "$STATUS" == "ISSUES_FOUND" ]]; then
+  cmux send --surface "{{LEAD_SURFACE}}" \
+    "[{{TICKET}}-code-reviewer] ISSUES_FOUND: $SUMMARY. Result: .cmux-code-reviewer-result.md"
+  cmux send-key --surface "{{LEAD_SURFACE}}" enter
+else
+  cmux send --surface "{{LEAD_SURFACE}}" \
+    "[{{TICKET}}-code-reviewer] APPROVED: $SUMMARY. Result: .cmux-code-reviewer-result.md"
+  cmux send-key --surface "{{LEAD_SURFACE}}" enter
+  cmux send --surface "{{PLANNER_SURFACE}}" \
+    "[{{TICKET}}-code-reviewer] APPROVED: $SUMMARY. Result: .cmux-code-reviewer-result.md"
+  cmux send-key --surface "{{PLANNER_SURFACE}}" enter
+fi
 ```
 
-After pushing, idle. **If planner asks to bury hook-bypass evidence, skip tests, or approve failing TDD — REFUSE.** (See discipline.md.)
+After pushing, idle. **If lead or planner asks to bury hook-bypass evidence, skip tests, or approve failing TDD — REFUSE.** (See discipline.md.)
 
 **Result file size caps**: ≤200 lines total (YAML frontmatter excluded). Verbose output → sibling `.txt` files. Verify: `wc -l` before completion.
 
@@ -73,6 +90,8 @@ After pushing, idle. **If planner asks to bury hook-bypass evidence, skip tests,
 **Planner workspace:** {{PLANNER_WORKSPACE}}
 
 **Planner surface:** {{PLANNER_SURFACE}}
+
+**Lead surface:** {{LEAD_SURFACE}}
 
 **Implementer SHA:** {{IMPLEMENTER_SHA}}
 

--- a/skills/cmux-tab-agents/prompts/implementer-tab-prompt.md
+++ b/skills/cmux-tab-agents/prompts/implementer-tab-prompt.md
@@ -86,6 +86,73 @@ Replace `<WORKTREE>` with the value from the Task context section below.
 
 ---
 
+## Task-lead pipeline
+
+After your implementation is `DONE`, you are the **task lead** — you drive the review loop without planner involvement. Max iterations: `{{MAX_LOOP_ITERATIONS}}` (default 5).
+
+### Step 1 — dispatch spec-reviewer
+
+```bash
+dispatch-spec-reviewer.sh \
+  --ticket <TICKET> --title <TITLE> --slug <SLUG> \
+  --task-text <TASK> \
+  --implementer-sha "$(git rev-parse HEAD)" \
+  --planner-surface <PLANNER_SURFACE> \
+  --lead-surface "$OWN_SURFACE"
+```
+
+Wait on your input box. The spec-reviewer will push back to `$OWN_SURFACE` (= `{{LEAD_SURFACE}}` when you are dispatched as lead).
+
+### Step 2 — spec-reviewer loop
+
+- **APPROVED** → proceed to Step 3 (code-reviewer).
+- **ISSUES_FOUND** → fix issues (TDD red-green), commit, then re-dispatch spec-reviewer. Increment iteration counter.
+  - If the **same issue is flagged twice in a row** → BLOCKED escalation (write `.cmux-task-result.md` with `status: BLOCKED`, push to planner).
+  - If **iteration counter ≥ {{MAX_LOOP_ITERATIONS}}** → BLOCKED escalation.
+
+### Step 3 — dispatch code-reviewer
+
+```bash
+dispatch-code-reviewer.sh \
+  --ticket <TICKET> --title <TITLE> --slug <SLUG> \
+  --task-text <TASK> \
+  --implementer-sha "$(git rev-parse HEAD)" \
+  --planner-surface <PLANNER_SURFACE> \
+  --lead-surface "$OWN_SURFACE"
+```
+
+### Step 4 — code-reviewer loop
+
+- **APPROVED** → proceed to Step 5.
+- **ISSUES_FOUND** → fix issues (TDD), commit, then re-dispatch code-reviewer. Increment counter.
+  - Same circuit-breaker rules as Step 2.
+
+### Step 5 — finish and report
+
+When **both reviewers have APPROVED**:
+
+1. Run `{{SKILL_BASE}}/scripts/finish-task.sh {{FINISH_MODE}} <WORKTREE>`.
+2. Write `.cmux-task-result.md` (schema in `references/reporting-contract.md`).
+3. Push **one line** to planner:
+
+```bash
+cmux send --surface "{{PLANNER_SURFACE}}" \
+  "[{{TICKET}}-implementer] DONE: <summary>. Result: <WORKTREE>/.cmux-task-result.md"
+cmux send-key --surface "{{PLANNER_SURFACE}}" enter
+```
+
+4. Idle.
+
+### Circuit-breaker (hard rule)
+
+BLOCKED if either:
+- Same reviewer flags the **same issue in two consecutive rounds**, or
+- Total loop iterations ≥ `{{MAX_LOOP_ITERATIONS}}`.
+
+On BLOCKED: write `.cmux-task-result.md` with `status: BLOCKED`, push to `{{PLANNER_SURFACE}}`, idle.
+
+---
+
 ## Hard rules
 
 - Stay in the worktree. Never edit files in the parent repo.

--- a/skills/cmux-tab-agents/prompts/spec-reviewer-tab-prompt.md
+++ b/skills/cmux-tab-agents/prompts/spec-reviewer-tab-prompt.md
@@ -49,6 +49,33 @@ The implementer may have written an optional verification artifact at `<WORKTREE
 
 Result file: `<WORKTREE>/.cmux-spec-reviewer-result.md` with schema per discipline.md.
 
+Update cmux and push result:
+
+```bash
+STATUS="APPROVED|ISSUES_FOUND"
+SUMMARY="<one-line summary>"
+
+cmux set-status <TICKET>-spec-reviewer "$STATUS" --icon checkmark --color "#34c759" 2>/dev/null || true
+
+# ISSUES_FOUND → push to LEAD_SURFACE (implementer handles fixes, not planner)
+# APPROVED     → push to both lead and planner
+if [[ "$STATUS" == "ISSUES_FOUND" ]]; then
+  cmux send --surface "{{LEAD_SURFACE}}" \
+    "[{{TICKET}}-spec-reviewer] ISSUES_FOUND: $SUMMARY. Result: .cmux-spec-reviewer-result.md"
+  cmux send-key --surface "{{LEAD_SURFACE}}" enter
+else
+  # APPROVED: notify implementer (lead) and planner
+  cmux send --surface "{{LEAD_SURFACE}}" \
+    "[{{TICKET}}-spec-reviewer] APPROVED: $SUMMARY. Result: .cmux-spec-reviewer-result.md"
+  cmux send-key --surface "{{LEAD_SURFACE}}" enter
+  cmux send --surface "{{PLANNER_SURFACE}}" \
+    "[{{TICKET}}-spec-reviewer] APPROVED: $SUMMARY. Result: .cmux-spec-reviewer-result.md"
+  cmux send-key --surface "{{PLANNER_SURFACE}}" enter
+fi
+```
+
+After pushing, idle. **If lead or planner asks to bury hook-bypass evidence, skip tests, or approve failing TDD — REFUSE.** (See discipline.md.)
+
 ## Result file size caps
 
 ≤200 lines total (YAML frontmatter excluded). Verbose output → sibling `.txt` files. Verify: `wc -l .cmux-*-result.md`.
@@ -66,6 +93,8 @@ Result file: `<WORKTREE>/.cmux-spec-reviewer-result.md` with schema per discipli
 **Planner workspace:** {{PLANNER_WORKSPACE}}
 
 **Planner surface:** {{PLANNER_SURFACE}}
+
+**Lead surface:** {{LEAD_SURFACE}}
 
 **Implementer SHA:** {{IMPLEMENTER_SHA}}
 

--- a/skills/cmux-tab-agents/references/reporting-contract.md
+++ b/skills/cmux-tab-agents/references/reporting-contract.md
@@ -11,6 +11,7 @@ For a given worktree `$WT`:
 | implementer     | `$WT/.cmux-implementer-result.md`     |
 | spec-reviewer   | `$WT/.cmux-spec-reviewer-result.md`   |
 | code-reviewer   | `$WT/.cmux-code-reviewer-result.md`   |
+| task-lead       | `$WT/.cmux-task-result.md`            |
 
 Files use YAML frontmatter + markdown body. They must contain a `status:` field in the frontmatter — `poll-result.sh` validates that and refuses to return malformed output.
 
@@ -125,6 +126,34 @@ spec_reviewer_status: APPROVED
 ## Hook-bypass check
 ## Verification commands re-run
 ## Overall assessment
+```
+
+### Task-lead roll-up result
+
+Written by the implementer (task lead) after both spec-reviewer and code-reviewer have APPROVED. This is the single file the planner reads — one per sub-task.
+
+```yaml
+---
+ticket: ALPM-1234-1
+phase: task-lead
+status: DONE | BLOCKED
+loop_iterations: 2
+---
+## Summary
+<2-3 sentences covering implementer + spec + code reviewer outcomes>
+
+## Files changed
+<git diff --name-only output>
+
+## Final commit SHA
+<sha>
+
+## Reviewer outcomes
+- spec-reviewer: APPROVED
+- code-reviewer: APPROVED
+
+## Blockers / concerns
+<bullet list, or "none">
 ```
 
 ## Verification artifact

--- a/skills/cmux-tab-agents/scripts/_dispatch_common.sh
+++ b/skills/cmux-tab-agents/scripts/_dispatch_common.sh
@@ -94,8 +94,10 @@ mapping = {
     "IMPLEMENTER_SHA":   os.environ.get("TPL_IMPL_SHA", ""),
     "TASK":              os.environ.get("TPL_TASK", ""),
     "FEEDBACK":          os.environ.get("TPL_FEEDBACK", ""),
-    "SKILL_BASE":        os.environ.get("TPL_SKILL_BASE", ""),
-    "FINISH_MODE":       os.environ.get("TPL_FINISH_MODE", ""),
+    "SKILL_BASE":           os.environ.get("TPL_SKILL_BASE", ""),
+    "FINISH_MODE":          os.environ.get("TPL_FINISH_MODE", ""),
+    "LEAD_SURFACE":         os.environ.get("TPL_LEAD_SURF", ""),
+    "MAX_LOOP_ITERATIONS":  os.environ.get("TPL_MAX_LOOP_ITER", ""),
 }
 with open(src, "r", encoding="utf-8") as f:
     body = f.read()
@@ -158,6 +160,7 @@ resolve_setting() {
 dispatch_main() {
   local TICKET="" TITLE="" SLUG="" TASK_TEXT="" TASK_FILE=""
   local TYPE="" PLANNER_WS="" PLANNER_SURFACE="" MODEL="" EFFORT="" IMPL_SHA="" FEEDBACK="" FIX_ONLY=0 FINISH_MODE="keep"
+  local LEAD_SURFACE="" MAX_LOOP_ITERATIONS="5"
 
   while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -174,6 +177,8 @@ dispatch_main() {
       --implementer-sha)     IMPL_SHA="$2"; shift 2 ;;
       --feedback-from-previous-review) FEEDBACK="$2"; shift 2 ;;
       --finish-mode)         FINISH_MODE="$2"; shift 2 ;;
+      --lead-surface)        LEAD_SURFACE="$2"; shift 2 ;;
+      --max-loop-iterations) MAX_LOOP_ITERATIONS="$2"; shift 2 ;;
       --fix-only)            FIX_ONLY=1; shift ;;
       -h|--help)             usage ;;
       *) echo "$0: unknown arg '$1'" >&2; usage ;;
@@ -277,6 +282,7 @@ print(d.get("caller",{}).get("pane_ref") or d.get("focused",{}).get("pane_ref","
     TPL_PWS="$PLANNER_WS" TPL_PSURF="$PLANNER_SURFACE" \
     TPL_IMPL_SHA="$IMPL_SHA" TPL_TASK="$TASK_TEXT" TPL_FEEDBACK="$FEEDBACK" \
     TPL_SKILL_BASE="$SKILL_ROOT" TPL_FINISH_MODE="$FINISH_MODE" \
+    TPL_LEAD_SURF="$LEAD_SURFACE" TPL_MAX_LOOP_ITER="$MAX_LOOP_ITERATIONS" \
     render_template "$TEMPLATE" "$RENDERED"
 
   # 3. Spawn a new tab in the planner's pane. Reuse the pane ref we already

--- a/skills/cmux-tab-agents/scripts/_dispatch_common.sh
+++ b/skills/cmux-tab-agents/scripts/_dispatch_common.sh
@@ -21,6 +21,8 @@ Usage: $0 --ticket TICKET --title TITLE --slug SLUG \\
           [--implementer-sha SHA] \\
           [--feedback-from-previous-review TEXT_OR_PATH] \\
           [--finish-mode MODE] \\
+          [--lead-surface REF] \\
+          [--max-loop-iterations N] \\
           [--fix-only]
 EOF
   exit 1

--- a/skills/cmux-tab-agents/scripts/tests/test_agent_loop.sh
+++ b/skills/cmux-tab-agents/scripts/tests/test_agent_loop.sh
@@ -55,7 +55,6 @@ Lead surface is: {{LEAD_SURFACE}}
 EOF
 (
   # shellcheck source=/dev/null
-  # shellcheck source=/dev/null
   . "$DISPATCH_COMMON"
   TPL_TICKET="" TPL_TITLE="" TPL_SLUG="" TPL_WORKTREE="" TPL_PWS="" \
   TPL_PSURF="" TPL_IMPL_SHA="" TPL_TASK="" TPL_FEEDBACK="" \
@@ -75,7 +74,6 @@ cat > "$tmpdir/tpl2.md" <<'EOF'
 Max iterations: {{MAX_LOOP_ITERATIONS}}
 EOF
 (
-  # shellcheck source=/dev/null
   # shellcheck source=/dev/null
   . "$DISPATCH_COMMON"
   TPL_TICKET="" TPL_TITLE="" TPL_SLUG="" TPL_WORKTREE="" TPL_PWS="" \
@@ -239,6 +237,7 @@ fi
 # T20: Rendered implementer prompt contains circuit-breaker prose (same issue twice → BLOCKED)
 if [[ -r "$impl_prompt" ]]; then
   (
+    # shellcheck source=/dev/null
     . "$DISPATCH_COMMON"
     TPL_TICKET="TEST-1" TPL_TITLE="Test" TPL_SLUG="test" TPL_WORKTREE="/tmp/wt" \
     TPL_PWS="surface:1" TPL_PSURF="surface:0" TPL_IMPL_SHA="abc1234" \
@@ -260,6 +259,7 @@ fi
 # T21: Rendered implementer prompt with MAX_LOOP_ITERATIONS=3 contains "3" and BLOCKED
 if [[ -r "$impl_prompt" ]]; then
   (
+    # shellcheck source=/dev/null
     . "$DISPATCH_COMMON"
     TPL_TICKET="TEST-1" TPL_TITLE="Test" TPL_SLUG="test" TPL_WORKTREE="/tmp/wt" \
     TPL_PWS="surface:1" TPL_PSURF="surface:0" TPL_IMPL_SHA="abc1234" \

--- a/skills/cmux-tab-agents/scripts/tests/test_agent_loop.sh
+++ b/skills/cmux-tab-agents/scripts/tests/test_agent_loop.sh
@@ -1,0 +1,236 @@
+#!/usr/bin/env bash
+# Tests for ISSUE-26: agent-to-agent review loop (implementer as task lead)
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+SKILL_ROOT="$(cd "$SCRIPTS_DIR/.." && pwd)"
+DISPATCH_COMMON="$SCRIPTS_DIR/_dispatch_common.sh"
+
+PASS=0
+FAIL=0
+
+pass() { printf 'PASS: %s\n' "$1"; PASS=$((PASS+1)); }
+fail() { printf 'FAIL: %s\n' "$1"; FAIL=$((FAIL+1)); }
+
+printf '=== ISSUE-26: agent loop / implementer-as-task-lead tests ===\n\n'
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+# T1: bash syntax check on _dispatch_common.sh
+if bash -n "$DISPATCH_COMMON" 2>/dev/null; then
+  pass "bash -n _dispatch_common.sh"
+else
+  fail "bash -n _dispatch_common.sh (syntax error)"
+fi
+
+# T2: --max-loop-iterations is recognized (no "unknown arg" error)
+out=$(cd "$tmpdir" && bash -c "
+  . '$DISPATCH_COMMON'
+  dispatch_main --ticket TEST-1 --title 'Test' --slug test \
+    --task-text 'task' --max-loop-iterations 5 2>&1
+" || true)
+if printf '%s' "$out" | grep -q "unknown arg.*max-loop"; then
+  fail "--max-loop-iterations flag not recognized: $out"
+else
+  pass "--max-loop-iterations flag is recognized"
+fi
+
+# T3: --lead-surface is recognized (no "unknown arg" error)
+out=$(cd "$tmpdir" && bash -c "
+  . '$DISPATCH_COMMON'
+  dispatch_main --ticket TEST-1 --title 'Test' --slug test \
+    --task-text 'task' --lead-surface 'surface:42' 2>&1
+" || true)
+if printf '%s' "$out" | grep -q "unknown arg.*lead-surface"; then
+  fail "--lead-surface flag not recognized: $out"
+else
+  pass "--lead-surface flag is recognized"
+fi
+
+# T4: render_template substitutes {{LEAD_SURFACE}}
+cat > "$tmpdir/tpl.md" <<'EOF'
+Lead surface is: {{LEAD_SURFACE}}
+EOF
+(
+  . "$DISPATCH_COMMON"
+  TPL_TICKET="" TPL_TITLE="" TPL_SLUG="" TPL_WORKTREE="" TPL_PWS="" \
+  TPL_PSURF="" TPL_IMPL_SHA="" TPL_TASK="" TPL_FEEDBACK="" \
+  TPL_SKILL_BASE="" TPL_FINISH_MODE="" TPL_LEAD_SURF="surface:99" \
+  TPL_MAX_LOOP_ITER="" \
+  render_template "$tmpdir/tpl.md" "$tmpdir/out.md"
+)
+rendered=$(cat "$tmpdir/out.md" 2>/dev/null || echo "")
+if printf '%s' "$rendered" | grep -q "surface:99"; then
+  pass "render_template substitutes {{LEAD_SURFACE}}"
+else
+  fail "render_template does not substitute {{LEAD_SURFACE}}: '$rendered'"
+fi
+
+# T5: render_template substitutes {{MAX_LOOP_ITERATIONS}}
+cat > "$tmpdir/tpl2.md" <<'EOF'
+Max iterations: {{MAX_LOOP_ITERATIONS}}
+EOF
+(
+  . "$DISPATCH_COMMON"
+  TPL_TICKET="" TPL_TITLE="" TPL_SLUG="" TPL_WORKTREE="" TPL_PWS="" \
+  TPL_PSURF="" TPL_IMPL_SHA="" TPL_TASK="" TPL_FEEDBACK="" \
+  TPL_SKILL_BASE="" TPL_FINISH_MODE="" TPL_LEAD_SURF="" \
+  TPL_MAX_LOOP_ITER="7" \
+  render_template "$tmpdir/tpl2.md" "$tmpdir/out2.md"
+)
+rendered2=$(cat "$tmpdir/out2.md" 2>/dev/null || echo "")
+if printf '%s' "$rendered2" | grep -q "Max iterations: 7"; then
+  pass "render_template substitutes {{MAX_LOOP_ITERATIONS}}"
+else
+  fail "render_template does not substitute {{MAX_LOOP_ITERATIONS}}: '$rendered2'"
+fi
+
+# T6: Implementer prompt contains task-lead pipeline section
+impl_prompt="$SKILL_ROOT/prompts/implementer-tab-prompt.md"
+if [[ -r "$impl_prompt" ]]; then
+  if grep -qiE "task.lead|task lead" "$impl_prompt"; then
+    pass "implementer prompt contains task-lead pipeline section"
+  else
+    fail "implementer prompt missing task-lead pipeline section"
+  fi
+else
+  fail "implementer prompt not found at $impl_prompt"
+fi
+
+# T7: Implementer prompt mentions dispatch-spec-reviewer after DONE
+if [[ -r "$impl_prompt" ]]; then
+  if grep -q "dispatch-spec-reviewer" "$impl_prompt"; then
+    pass "implementer prompt references dispatch-spec-reviewer"
+  else
+    fail "implementer prompt does not reference dispatch-spec-reviewer"
+  fi
+fi
+
+# T8: Implementer prompt mentions circuit-breaker
+if [[ -r "$impl_prompt" ]]; then
+  if grep -qiE "circuit.breaker|circuit_breaker|same issue twice|max.*iter|BLOCKED" "$impl_prompt"; then
+    pass "implementer prompt mentions circuit-breaker / BLOCKED escalation"
+  else
+    fail "implementer prompt missing circuit-breaker instructions"
+  fi
+fi
+
+# T9: Implementer prompt has {{MAX_LOOP_ITERATIONS}} placeholder
+if [[ -r "$impl_prompt" ]]; then
+  if grep -q "{{MAX_LOOP_ITERATIONS}}" "$impl_prompt"; then
+    pass "implementer prompt has {{MAX_LOOP_ITERATIONS}} placeholder"
+  else
+    fail "implementer prompt missing {{MAX_LOOP_ITERATIONS}} placeholder"
+  fi
+fi
+
+# T10: Spec-reviewer prompt has {{LEAD_SURFACE}} placeholder
+spec_prompt="$SKILL_ROOT/prompts/spec-reviewer-tab-prompt.md"
+if [[ -r "$spec_prompt" ]]; then
+  if grep -q "{{LEAD_SURFACE}}" "$spec_prompt"; then
+    pass "spec-reviewer prompt has {{LEAD_SURFACE}} placeholder"
+  else
+    fail "spec-reviewer prompt missing {{LEAD_SURFACE}} placeholder"
+  fi
+else
+  fail "spec-reviewer prompt not found at $spec_prompt"
+fi
+
+# T11: Spec-reviewer prompt pushes ISSUES_FOUND to LEAD_SURFACE (not just PLANNER_SURFACE)
+if [[ -r "$spec_prompt" ]]; then
+  if grep -qE "LEAD_SURFACE.*ISSUES_FOUND|ISSUES_FOUND.*LEAD_SURFACE|lead.*surface.*issues|issues.*lead.*surface" "$spec_prompt" \
+     || (grep -q "ISSUES_FOUND" "$spec_prompt" && grep -q "LEAD_SURFACE" "$spec_prompt"); then
+    pass "spec-reviewer prompt references LEAD_SURFACE for ISSUES_FOUND"
+  else
+    fail "spec-reviewer prompt does not reference LEAD_SURFACE for ISSUES_FOUND"
+  fi
+fi
+
+# T12: Code-reviewer prompt has {{LEAD_SURFACE}} placeholder
+code_prompt="$SKILL_ROOT/prompts/code-reviewer-tab-prompt.md"
+if [[ -r "$code_prompt" ]]; then
+  if grep -q "{{LEAD_SURFACE}}" "$code_prompt"; then
+    pass "code-reviewer prompt has {{LEAD_SURFACE}} placeholder"
+  else
+    fail "code-reviewer prompt missing {{LEAD_SURFACE}} placeholder"
+  fi
+else
+  fail "code-reviewer prompt not found at $code_prompt"
+fi
+
+# T13: Code-reviewer prompt pushes ISSUES_FOUND to LEAD_SURFACE
+if [[ -r "$code_prompt" ]]; then
+  if grep -q "ISSUES_FOUND" "$code_prompt" && grep -q "LEAD_SURFACE" "$code_prompt"; then
+    pass "code-reviewer prompt references LEAD_SURFACE for ISSUES_FOUND"
+  else
+    fail "code-reviewer prompt does not reference LEAD_SURFACE for ISSUES_FOUND"
+  fi
+fi
+
+# T14: reporting-contract.md documents .cmux-task-result.md
+contract="$SKILL_ROOT/references/reporting-contract.md"
+if [[ -r "$contract" ]]; then
+  if grep -q "cmux-task-result" "$contract"; then
+    pass "reporting-contract.md documents .cmux-task-result.md"
+  else
+    fail "reporting-contract.md missing .cmux-task-result.md documentation"
+  fi
+else
+  fail "reporting-contract.md not found"
+fi
+
+# T15: SKILL.md updated — planner no longer dispatches reviewers directly
+skill_md="$SKILL_ROOT/SKILL.md"
+if [[ -r "$skill_md" ]]; then
+  if grep -qiE "implementer.*review.*loop|implementer.*task.lead|review.*loop.*without.*planner" "$skill_md"; then
+    pass "SKILL.md documents implementer-as-task-lead loop"
+  else
+    fail "SKILL.md not updated for implementer-as-task-lead loop"
+  fi
+else
+  fail "SKILL.md not found"
+fi
+
+# T16: CHANGELOG.md has entry for ISSUE-26
+changelog="$SKILL_ROOT/CHANGELOG.md"
+if [[ -r "$changelog" ]]; then
+  if grep -qiE "ISSUE-26|agent.*loop.*without.*planner|review loop|task.lead" "$changelog"; then
+    pass "CHANGELOG.md has entry for ISSUE-26"
+  else
+    fail "CHANGELOG.md missing entry for ISSUE-26"
+  fi
+else
+  fail "CHANGELOG.md not found"
+fi
+
+# T17: Implementer prompt has {{LEAD_SURFACE}} placeholder (for spawning reviewers)
+if [[ -r "$impl_prompt" ]]; then
+  if grep -q "{{LEAD_SURFACE}}" "$impl_prompt" || grep -q "lead.surface\|lead_surface" "$impl_prompt"; then
+    pass "implementer prompt references lead surface concept"
+  else
+    fail "implementer prompt missing lead surface reference"
+  fi
+fi
+
+# T18: Spec-reviewer prompt task context includes LEAD_SURFACE field
+if [[ -r "$spec_prompt" ]]; then
+  if grep -qE "Lead surface|lead_surface|\*\*Lead" "$spec_prompt"; then
+    pass "spec-reviewer task context has lead surface field"
+  else
+    fail "spec-reviewer task context missing lead surface field"
+  fi
+fi
+
+# T19: Code-reviewer prompt task context includes LEAD_SURFACE field
+if [[ -r "$code_prompt" ]]; then
+  if grep -qE "Lead surface|lead_surface|\*\*Lead" "$code_prompt"; then
+    pass "code-reviewer task context has lead surface field"
+  else
+    fail "code-reviewer task context missing lead surface field"
+  fi
+fi
+
+printf '\n=== Results: %d passed, %d failed ===\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/skills/cmux-tab-agents/scripts/tests/test_agent_loop.sh
+++ b/skills/cmux-tab-agents/scripts/tests/test_agent_loop.sh
@@ -54,6 +54,8 @@ cat > "$tmpdir/tpl.md" <<'EOF'
 Lead surface is: {{LEAD_SURFACE}}
 EOF
 (
+  # shellcheck source=/dev/null
+  # shellcheck source=/dev/null
   . "$DISPATCH_COMMON"
   TPL_TICKET="" TPL_TITLE="" TPL_SLUG="" TPL_WORKTREE="" TPL_PWS="" \
   TPL_PSURF="" TPL_IMPL_SHA="" TPL_TASK="" TPL_FEEDBACK="" \
@@ -73,6 +75,8 @@ cat > "$tmpdir/tpl2.md" <<'EOF'
 Max iterations: {{MAX_LOOP_ITERATIONS}}
 EOF
 (
+  # shellcheck source=/dev/null
+  # shellcheck source=/dev/null
   . "$DISPATCH_COMMON"
   TPL_TICKET="" TPL_TITLE="" TPL_SLUG="" TPL_WORKTREE="" TPL_PWS="" \
   TPL_PSURF="" TPL_IMPL_SHA="" TPL_TASK="" TPL_FEEDBACK="" \

--- a/skills/cmux-tab-agents/scripts/tests/test_agent_loop.sh
+++ b/skills/cmux-tab-agents/scripts/tests/test_agent_loop.sh
@@ -232,5 +232,61 @@ if [[ -r "$code_prompt" ]]; then
   fi
 fi
 
+# T20: Rendered implementer prompt contains circuit-breaker prose (same issue twice → BLOCKED)
+if [[ -r "$impl_prompt" ]]; then
+  (
+    . "$DISPATCH_COMMON"
+    TPL_TICKET="TEST-1" TPL_TITLE="Test" TPL_SLUG="test" TPL_WORKTREE="/tmp/wt" \
+    TPL_PWS="surface:1" TPL_PSURF="surface:0" TPL_IMPL_SHA="abc1234" \
+    TPL_TASK="task text" TPL_FEEDBACK="" TPL_SKILL_BASE="/tmp/skill" \
+    TPL_FINISH_MODE="pr" TPL_LEAD_SURF="surface:42" TPL_MAX_LOOP_ITER="5" \
+    render_template "$impl_prompt" "$tmpdir/rendered_impl.md"
+  )
+  rendered_impl=$(cat "$tmpdir/rendered_impl.md" 2>/dev/null || echo "")
+  if printf '%s' "$rendered_impl" | grep -q "same issue" && \
+     printf '%s' "$rendered_impl" | grep -q "BLOCKED"; then
+    pass "rendered implementer prompt: circuit-breaker (same issue twice → BLOCKED) present"
+  else
+    fail "rendered implementer prompt missing circuit-breaker prose (same issue + BLOCKED)"
+  fi
+else
+  fail "implementer prompt not found for T20"
+fi
+
+# T21: Rendered implementer prompt with MAX_LOOP_ITERATIONS=3 contains "3" and BLOCKED
+if [[ -r "$impl_prompt" ]]; then
+  (
+    . "$DISPATCH_COMMON"
+    TPL_TICKET="TEST-1" TPL_TITLE="Test" TPL_SLUG="test" TPL_WORKTREE="/tmp/wt" \
+    TPL_PWS="surface:1" TPL_PSURF="surface:0" TPL_IMPL_SHA="abc1234" \
+    TPL_TASK="task text" TPL_FEEDBACK="" TPL_SKILL_BASE="/tmp/skill" \
+    TPL_FINISH_MODE="pr" TPL_LEAD_SURF="surface:42" TPL_MAX_LOOP_ITER="3" \
+    render_template "$impl_prompt" "$tmpdir/rendered_impl_3.md"
+  )
+  rendered_impl3=$(cat "$tmpdir/rendered_impl_3.md" 2>/dev/null || echo "")
+  if printf '%s' "$rendered_impl3" | grep -q "3" && \
+     printf '%s' "$rendered_impl3" | grep -q "BLOCKED"; then
+    pass "rendered implementer prompt (MAX_LOOP_ITERATIONS=3): max-iterations BLOCKED prose present"
+  else
+    fail "rendered implementer prompt missing max-iterations BLOCKED prose with value 3"
+  fi
+else
+  fail "implementer prompt not found for T21"
+fi
+
+# T22: Rendered implementer prompt contains happy-path terminal state (finish-task.sh + .cmux-task-result.md + DONE)
+if [[ -r "$impl_prompt" ]]; then
+  rendered_impl=$(cat "$tmpdir/rendered_impl.md" 2>/dev/null || echo "")
+  if printf '%s' "$rendered_impl" | grep -q "finish-task.sh" && \
+     printf '%s' "$rendered_impl" | grep -q "cmux-task-result" && \
+     printf '%s' "$rendered_impl" | grep -q "DONE"; then
+    pass "rendered implementer prompt: happy-path terminal state (finish-task.sh + .cmux-task-result.md + DONE) present"
+  else
+    fail "rendered implementer prompt missing happy-path terminal state wiring"
+  fi
+else
+  fail "implementer prompt not found for T22"
+fi
+
 printf '\n=== Results: %d passed, %d failed ===\n' "$PASS" "$FAIL"
 [[ "$FAIL" -eq 0 ]]

--- a/skills/cmux-tab-agents/tests/test_agent_loop.sh
+++ b/skills/cmux-tab-agents/tests/test_agent_loop.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+# test_agent_loop.sh
+# Verify agent-loop flags (--lead-surface, --max-loop-iterations) are rendered
+# correctly in implementer, spec-reviewer, and code-reviewer prompts.
+# Shell-level render-and-grep tests — no live cmux needed.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SCRIPTS_DIR="$SKILL_ROOT/scripts"
+PROMPTS_DIR="$SKILL_ROOT/prompts"
+
+TMPDIR=$(mktemp -d)
+trap "rm -rf $TMPDIR" EXIT
+
+PASS=0
+FAIL=0
+
+pass() { echo "PASS: $1"; ((PASS++)) || true; }
+fail() { echo "FAIL: $1"; ((FAIL++)) || true; }
+
+# Render a prompt template using _dispatch_common.sh's render_template function.
+render() {
+  local phase="$1" outfile="$2"
+  shift 2
+  # Set required env vars
+  export TPL_TICKET="ISSUE-99"
+  export TPL_TITLE="Test issue"
+  export TPL_SLUG="test-issue"
+  export TPL_WORKTREE="/tmp/test-wt"
+  export TPL_PWS="ws-abc"
+  export TPL_PSURF="surface:0"
+  export TPL_IMPL_SHA="deadbeef"
+  export TPL_TASK="Do the thing"
+  export TPL_FEEDBACK=""
+  export TPL_LEAD_SURF="${LEAD_SURF:-surface:7}"
+  export TPL_MAX_LOOP_ITER="${MAX_LOOP_ITER:-5}"
+  export PHASE="$phase"
+  # Additional vars used by some phases
+  export TPL_SPEC_SHA="${TPL_SPEC_SHA:-}"
+  export TPL_CODE_SHA="${TPL_CODE_SHA:-}"
+  export TPL_FINISH_MODE="${TPL_FINISH_MODE:-}"
+  export TPL_FIX_ONLY="${TPL_FIX_ONLY:-}"
+  export TPL_EFFORT="${TPL_EFFORT:-}"
+  export TPL_MODEL="${TPL_MODEL:-}"
+  export TPL_TYPE="${TPL_TYPE:-}"
+
+  source "$SCRIPTS_DIR/_dispatch_common.sh"
+  render_template "$PROMPTS_DIR/${phase}-tab-prompt.md" "$outfile"
+}
+
+# ---------------------------------------------------------------------------
+# Test 1: Happy path — {{LEAD_SURFACE}} replaced in implementer prompt
+# ---------------------------------------------------------------------------
+echo "Test 1: {{LEAD_SURFACE}} replaced in implementer prompt..."
+LEAD_SURF="surface:7" MAX_LOOP_ITER="5"
+OUT="$TMPDIR/impl.md"
+render "implementer" "$OUT"
+if grep -q 'surface:7' "$OUT" && ! grep -q '{{LEAD_SURFACE}}' "$OUT"; then
+  pass "LEAD_SURFACE substituted in implementer prompt"
+else
+  fail "LEAD_SURFACE not substituted in implementer prompt"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 2: Happy path — {{MAX_LOOP_ITERATIONS}} replaced in implementer prompt
+# ---------------------------------------------------------------------------
+echo "Test 2: {{MAX_LOOP_ITERATIONS}} replaced in implementer prompt..."
+if grep -q '5' "$OUT" && ! grep -q '{{MAX_LOOP_ITERATIONS}}' "$OUT"; then
+  pass "MAX_LOOP_ITERATIONS substituted in implementer prompt"
+else
+  fail "MAX_LOOP_ITERATIONS not substituted in implementer prompt"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 3: Circuit-breaker token replaced with custom max-iterations value
+# ---------------------------------------------------------------------------
+echo "Test 3: Custom --max-loop-iterations (3) rendered correctly..."
+LEAD_SURF="surface:7" MAX_LOOP_ITER="3"
+OUT3="$TMPDIR/impl-iter3.md"
+render "implementer" "$OUT3"
+if grep -q '3' "$OUT3" && ! grep -q '{{MAX_LOOP_ITERATIONS}}' "$OUT3"; then
+  pass "Custom MAX_LOOP_ITERATIONS=3 rendered in implementer prompt"
+else
+  fail "Custom MAX_LOOP_ITERATIONS=3 not rendered in implementer prompt"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 4: {{LEAD_SURFACE}} replaced in spec-reviewer prompt
+# ---------------------------------------------------------------------------
+echo "Test 4: {{LEAD_SURFACE}} replaced in spec-reviewer prompt..."
+LEAD_SURF="surface:9" MAX_LOOP_ITER="5"
+SOUT="$TMPDIR/spec-rev.md"
+render "spec-reviewer" "$SOUT"
+if grep -q 'surface:9' "$SOUT" && ! grep -q '{{LEAD_SURFACE}}' "$SOUT"; then
+  pass "LEAD_SURFACE substituted in spec-reviewer prompt"
+else
+  fail "LEAD_SURFACE not substituted in spec-reviewer prompt"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 5: spec-reviewer ISSUES_FOUND routing points to LEAD_SURFACE
+# ---------------------------------------------------------------------------
+echo "Test 5: spec-reviewer ISSUES_FOUND routes to LEAD_SURFACE..."
+if grep -A3 'ISSUES_FOUND' "$SOUT" | grep -q 'surface:9'; then
+  pass "spec-reviewer ISSUES_FOUND routes to LEAD_SURFACE"
+else
+  fail "spec-reviewer ISSUES_FOUND does not route to LEAD_SURFACE"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 6: {{LEAD_SURFACE}} replaced in code-reviewer prompt
+# ---------------------------------------------------------------------------
+echo "Test 6: {{LEAD_SURFACE}} replaced in code-reviewer prompt..."
+LEAD_SURF="surface:9" MAX_LOOP_ITER="5"
+COUT="$TMPDIR/code-rev.md"
+render "code-reviewer" "$COUT"
+if grep -q 'surface:9' "$COUT" && ! grep -q '{{LEAD_SURFACE}}' "$COUT"; then
+  pass "LEAD_SURFACE substituted in code-reviewer prompt"
+else
+  fail "LEAD_SURFACE not substituted in code-reviewer prompt"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 7: code-reviewer ISSUES_FOUND routing points to LEAD_SURFACE
+# ---------------------------------------------------------------------------
+echo "Test 7: code-reviewer ISSUES_FOUND routes to LEAD_SURFACE..."
+if grep -A3 'ISSUES_FOUND' "$COUT" | grep -q 'surface:9'; then
+  pass "code-reviewer ISSUES_FOUND routes to LEAD_SURFACE"
+else
+  fail "code-reviewer ISSUES_FOUND does not route to LEAD_SURFACE"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 8: No unreplaced {{PLACEHOLDER}} tokens remain in any rendered prompt
+# ---------------------------------------------------------------------------
+echo "Test 8: No unreplaced placeholders in rendered prompts..."
+LEFTOVERS=0
+for f in "$TMPDIR"/*.md; do
+  if grep -q '{{[A-Z_]*}}' "$f"; then
+    echo "  Unreplaced placeholder(s) in $f:"
+    grep '{{[A-Z_]*}}' "$f"
+    ((LEFTOVERS++)) || true
+  fi
+done
+if [[ $LEFTOVERS -eq 0 ]]; then
+  pass "No unreplaced placeholders in any rendered prompt"
+else
+  fail "Unreplaced placeholders found in $LEFTOVERS file(s)"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+if [[ $FAIL -gt 0 ]]; then
+  exit 1
+fi
+echo "All tests passed!"


### PR DESCRIPTION
Closes #26.

## Summary

- Implementer becomes the **task lead**: spawns spec-reviewer and code-reviewer itself, loops with them directly via `cmux send`, and delivers one terminal push to the planner (`DONE` or `BLOCKED`)
- New flags: `--lead-surface` on reviewer dispatch scripts, `--max-loop-iterations` on implementer dispatch (default 5)
- New placeholders: `{{LEAD_SURFACE}}`, `{{MAX_LOOP_ITERATIONS}}` substituted by `_dispatch_common.sh`
- Reviewer prompts route `ISSUES_FOUND` → `{{LEAD_SURFACE}}`; `APPROVED` → both lead and planner
- Circuit-breaker: same issue flagged twice in a row → `BLOCKED`; ≥ `MAX_LOOP_ITERATIONS` → `BLOCKED`
- New `.cmux-task-result.md` roll-up schema (planner reads one file per sub-task, not three)
- `SKILL.md` updated: planner dispatches implementer only; reviewer scripts retained for manual use
- 22 tests in `scripts/tests/test_agent_loop.sh` + 8 in `tests/test_agent_loop.sh`

## Test plan

- [ ] CI lint passes
- [ ] CI test passes (all new test_agent_loop tests + full prior suite)
- [ ] `{{LEAD_SURFACE}}` substituted in reviewer seeds
- [ ] `{{MAX_LOOP_ITERATIONS}}` substituted in implementer seed
- [ ] Reviewer ISSUES_FOUND routes to lead surface (grep check in tests)
- [ ] Circuit-breaker and happy-path terminal state prose present in rendered implementer prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)