### PR TITLE
fix(ISSUE-49): ensure-worktree.sh branches from origin/main not stale local main

### DIFF
--- a/skills/cmux-tab-agents/CHANGELOG.md
+++ b/skills/cmux-tab-agents/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to cmux-tab-agents are documented here.
 
+## Fixed
+
+- **`ensure-worktree.sh` branches from stale local main** (ISSUE-49): `ensure-worktree.sh` now fetches `origin/main` and branches new worktrees from it instead of a potentially stale local `main`. This eliminates the need to manually pull before creating a worktree and prevents inheriting out-of-date bases. Idempotent resume logic preserved: if a branch already exists, it is reused as before.
+
 ## Changed
 
 - **Agent-to-agent review loop without planner involvement during iteration** (ISSUE-26): The implementer is now the **task lead** — it dispatches spec-reviewer and code-reviewer itself, loops on ISSUES_FOUND, and pushes one terminal message to the planner. New flags: `dispatch-implementer.sh --max-loop-iterations <n>` (default 5); `dispatch-spec-reviewer.sh` and `dispatch-code-reviewer.sh` accept `--lead-surface` so reviewers push ISSUES_FOUND back to the implementer and APPROVED to both implementer and planner. New `{{LEAD_SURFACE}}` and `{{MAX_LOOP_ITERATIONS}}` template placeholders in `_dispatch_common.sh`. Circuit-breaker fires on same issue twice or max iterations → BLOCKED escalation to planner. New roll-up file `.cmux-task-result.md` written by the implementer after all reviews pass. SKILL.md updated: planner dispatches `dispatch-implementer.sh` only; `dispatch-spec-reviewer.sh` and `dispatch-code-reviewer.sh` retained for manual use.

--- a/skills/cmux-tab-agents/scripts/ensure-worktree.sh
+++ b/skills/cmux-tab-agents/scripts/ensure-worktree.sh
@@ -135,11 +135,14 @@ fi
 
 mkdir -p "$(dirname "$WT")"
 
-# Reuse branch if it already exists; otherwise create it off the default.
+# Fetch origin/main to ensure fresh base (not stale local main)
+git -C "$REPO" fetch origin main --quiet 2>/dev/null || true
+
+# Reuse branch if it already exists; otherwise create it off origin/main.
 if git -C "$REPO" show-ref --verify --quiet "refs/heads/$BRANCH"; then
   git -C "$REPO" worktree add "$WT" "$BRANCH" >&2
 else
-  git -C "$REPO" worktree add "$WT" -b "$BRANCH" "$DEFAULT_BRANCH" >&2
+  git -C "$REPO" worktree add "$WT" -b "$BRANCH" origin/main >&2
 fi
 
 # 5. Best-effort project bootstrap

--- a/skills/cmux-tab-agents/scripts/tests/test_ensure_worktree_origin_main.sh
+++ b/skills/cmux-tab-agents/scripts/tests/test_ensure_worktree_origin_main.sh
@@ -30,7 +30,7 @@ cd "$tmpdir" || exit 1
 # Create initial repo with commit 1
 initial_repo="$tmpdir/initial"
 git init -q -b main "$initial_repo"
-cd "$initial_repo"
+cd "$initial_repo" || exit 1
 git config user.email "test@example.com"
 git config user.name "Test User"
 touch file1.txt
@@ -45,12 +45,12 @@ git clone -q --bare . "$bare_repo"
 # Clone to get a working copy
 local_repo="$tmpdir/repo"
 git clone -q "$bare_repo" "$local_repo"
-cd "$local_repo"
+cd "$local_repo" || exit 1
 git config user.email "test@example.com"
 git config user.name "Test User"
 
 # Now push additional commits from the initial_repo to origin
-cd "$initial_repo"
+cd "$initial_repo" || exit 1
 touch file2.txt
 git add file2.txt
 git commit -q -m "commit 2"
@@ -58,7 +58,7 @@ commit2=$(git rev-parse HEAD)
 git push -q "$bare_repo" main
 
 # Go back to local_repo and fetch (without pulling)
-cd "$local_repo"
+cd "$local_repo" || exit 1
 git fetch -q origin
 
 # Verify local main is behind origin/main

--- a/skills/cmux-tab-agents/scripts/tests/test_ensure_worktree_origin_main.sh
+++ b/skills/cmux-tab-agents/scripts/tests/test_ensure_worktree_origin_main.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Test ensure-worktree.sh branches from origin/main instead of stale local main
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+ENSURE_WT="$SCRIPTS_DIR/ensure-worktree.sh"
+
+PASS=0
+FAIL=0
+
+pass() { printf 'PASS: %s\n' "$1"; PASS=$((PASS+1)); }
+fail() { printf 'FAIL: %s\n' "$1"; FAIL=$((FAIL+1)); }
+
+printf '=== ensure-worktree.sh origin/main tests ===\n\n'
+
+# T1: Syntax check
+if bash -n "$ENSURE_WT" 2>/dev/null; then
+  pass "bash -n ensure-worktree.sh"
+else
+  fail "bash -n ensure-worktree.sh (syntax error)"
+  exit 1
+fi
+
+# T2: Test branching from origin/main when local main is stale
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+cd "$tmpdir" || exit 1
+
+# Create initial repo with commit 1
+initial_repo="$tmpdir/initial"
+git init -q -b main "$initial_repo"
+cd "$initial_repo"
+git config user.email "test@example.com"
+git config user.name "Test User"
+touch file1.txt
+git add file1.txt
+git commit -q -m "commit 1"
+commit1=$(git rev-parse HEAD)
+
+# Create bare repo as origin
+bare_repo="$tmpdir/origin.git"
+git clone -q --bare . "$bare_repo"
+
+# Clone to get a working copy
+local_repo="$tmpdir/repo"
+git clone -q "$bare_repo" "$local_repo"
+cd "$local_repo"
+git config user.email "test@example.com"
+git config user.name "Test User"
+
+# Now push additional commits from the initial_repo to origin
+cd "$initial_repo"
+touch file2.txt
+git add file2.txt
+git commit -q -m "commit 2"
+commit2=$(git rev-parse HEAD)
+git push -q "$bare_repo" main
+
+# Go back to local_repo and fetch (without pulling)
+cd "$local_repo"
+git fetch -q origin
+
+# Verify local main is behind origin/main
+local_main=$(git rev-parse main)
+origin_main=$(git rev-parse origin/main)
+
+if [[ "$local_main" == "$commit1" ]] && [[ "$origin_main" == "$commit2" ]]; then
+  pass "local main is stale, behind origin/main"
+else
+  fail "failed to set up stale main scenario (local=$local_main, origin=$origin_main, expect local=$commit1, origin=$commit2)"
+  exit 1
+fi
+
+# Create worktree base directory
+wt_base="$tmpdir/worktrees"
+mkdir -p "$wt_base"
+
+# Call ensure-worktree.sh
+wt_path=$("$ENSURE_WT" --ticket TEST-1 --slug test-slug --type feat 2>/dev/null || echo "")
+
+if [[ -z "$wt_path" ]]; then
+  fail "ensure-worktree.sh failed to create worktree"
+  exit 1
+fi
+
+if ! [[ -d "$wt_path" ]]; then
+  fail "worktree path does not exist: $wt_path"
+  exit 1
+fi
+
+pass "worktree created successfully"
+
+# Check that the worktree is based on origin/main (commit2), not stale local main (commit1)
+wt_head=$(cd "$wt_path" && git rev-parse HEAD)
+
+if [[ "$wt_head" == "$commit2" ]]; then
+  pass "worktree is based on origin/main (fresh commit)"
+elif [[ "$wt_head" == "$commit1" ]]; then
+  fail "worktree is based on stale local main (should be origin/main)"
+else
+  fail "worktree HEAD is unexpected: $wt_head (expected $commit2 or $commit1)"
+fi
+
+# Summary
+printf '\n=== Results ===\n'
+printf 'PASS: %d\n' "$PASS"
+printf 'FAIL: %d\n' "$FAIL"
+
+[[ $FAIL -eq 0 ]] && exit 0 || exit 1


### PR DESCRIPTION
Closes #49.

## Summary

- `ensure-worktree.sh` now runs `git fetch origin main` before creating the worktree
- New branches based on `origin/main` instead of local `main`, eliminating stale-base rebase overhead
- Idempotent: existing worktrees still resume correctly
- Non-blocking note from code-reviewer: hardcodes `origin/main` (good enough for this repo; non-main repos can open a follow-up)

## Test plan

- [ ] CI lint passes
- [ ] CI test passes (4 new tests including stale-main scenario)

🤖 Generated with [Claude Code](https://claude.com/claude-code)