### PR TITLE
feat(VALIDATE-002): autonomous verdict reaction via --verbose close-surfaces

### DIFF
--- a/skills/cmux-tab-agents/scripts/cleanup-helper.sh
+++ b/skills/cmux-tab-agents/scripts/cleanup-helper.sh
@@ -262,12 +262,29 @@ cmd_close_surfaces() {
 
   for ref in "${surfaces[@]}"; do
     if [[ "$apply" == true ]]; then
+      # Look the surface up first so a missing ref is distinguishable from a
+      # real close-RPC failure. In --verbose mode we re-emit cmux's stderr so
+      # operators can see why the lookup failed.
+      local lookup_err
+      lookup_err=$(cmux get-surface --surface "$ref" 2>&1 >/dev/null) || {
+        if [[ "$verbose" == true ]]; then
+          printf '[verbose] not found: %s\n' "$ref"
+          [[ -n "$lookup_err" ]] && printf '[verbose] cmux: %s\n' "$lookup_err"
+        fi
+        log "  (surface $ref not found; skipping)"
+        continue
+      }
+
       log "Closing surface: $ref"
       [[ "$verbose" == true ]] && printf '[verbose] attempting close: %s\n' "$ref"
-      if cmux close-surface --surface "$ref" 2>/dev/null; then
+      local close_err
+      if close_err=$(cmux close-surface --surface "$ref" 2>&1 >/dev/null); then
         [[ "$verbose" == true ]] && printf '[verbose] closed ok: %s\n' "$ref"
       else
-        [[ "$verbose" == true ]] && printf '[verbose] close failed: %s\n' "$ref"
+        if [[ "$verbose" == true ]]; then
+          printf '[verbose] close failed: %s\n' "$ref"
+          [[ -n "$close_err" ]] && printf '[verbose] cmux: %s\n' "$close_err"
+        fi
         log "  (could not close $ref)"
       fi
     else

--- a/skills/cmux-tab-agents/scripts/cleanup-helper.sh
+++ b/skills/cmux-tab-agents/scripts/cleanup-helper.sh
@@ -4,7 +4,8 @@
 # Subcommands (all dry-run by default; pass --apply to mutate):
 #   discover [--apply]               — emit JSON of four cleanup-candidate categories;
 #                                       with --apply, also runs each apply step in one pass
-#   close-surfaces [--apply] <ref>…  — close idle cmux surfaces
+#   close-surfaces [--apply] [--verbose] <ref>…  — close idle cmux surfaces
+#                                       (--verbose prints per-surface details)
 #   remove-worktrees [--apply] <path>… — remove stale worktree directories
 #   delete-branches [--apply] <repo> <branch>… — delete merged git branches (safe: -d only)
 #   prune-streams [--apply] <path>…  — remove orphaned agent JSONL event files
@@ -29,7 +30,8 @@ Usage: cleanup-helper.sh <subcommand> [--apply] [args...]
 Subcommands:
   discover [--apply]                Emit JSON with cleanup candidates;
                                     with --apply, immediately runs each apply step
-  close-surfaces [--apply] <ref>…   Close idle cmux surfaces (dry-run by default)
+  close-surfaces [--apply] [--verbose] <ref>…   Close idle cmux surfaces (dry-run by default;
+                                                 --verbose prints per-surface details)
   remove-worktrees [--apply] <p>…   Remove stale worktree directories (dry-run by default)
   delete-branches [--apply] <repo> <branch>…  Delete merged branches via git branch -d (dry-run by default)
   prune-streams [--apply] <path>…   Remove orphaned agent JSONL files (dry-run by default)
@@ -243,10 +245,12 @@ for b in json.load(sys.stdin):
 
 cmd_close_surfaces() {
   local apply=false
+  local verbose=false
   local surfaces=()
   while [[ $# -gt 0 ]]; do
     case "$1" in
-      --apply) apply=true; shift ;;
+      --apply)   apply=true;   shift ;;
+      --verbose) verbose=true; shift ;;
       *) surfaces+=("$1"); shift ;;
     esac
   done
@@ -259,9 +263,16 @@ cmd_close_surfaces() {
   for ref in "${surfaces[@]}"; do
     if [[ "$apply" == true ]]; then
       log "Closing surface: $ref"
-      cmux close-surface --surface "$ref" 2>/dev/null || log "  (could not close $ref)"
+      [[ "$verbose" == true ]] && printf '[verbose] attempting close: %s\n' "$ref"
+      if cmux close-surface --surface "$ref" 2>/dev/null; then
+        [[ "$verbose" == true ]] && printf '[verbose] closed ok: %s\n' "$ref"
+      else
+        [[ "$verbose" == true ]] && printf '[verbose] close failed: %s\n' "$ref"
+        log "  (could not close $ref)"
+      fi
     else
       printf '[dry-run] would close surface: %s\n' "$ref"
+      [[ "$verbose" == true ]] && printf '[verbose] candidate: %s\n' "$ref"
     fi
   done
 }

--- a/skills/cmux-tab-agents/scripts/tests/test_cleanup_helper.sh
+++ b/skills/cmux-tab-agents/scripts/tests/test_cleanup_helper.sh
@@ -56,7 +56,9 @@ exit 1
 MOCK_GH
   chmod +x "$mockdir/bin/gh"
 
-  # mock cmux — supports `tree` and `close-surface`
+  # mock cmux — supports `tree`, `get-surface`, and `close-surface`.
+  # get-surface returns 0 iff the ref is listed in <config>/known_surfaces,
+  # or if known_surfaces does not exist (back-compat default).
   cat > "$mockdir/bin/cmux" <<'MOCK_CMUX'
 #!/usr/bin/env bash
 CONFIG="$(dirname "$(dirname "$0")")/mock-config"
@@ -64,6 +66,17 @@ case "$1" in
   tree)
     if [[ -f "$CONFIG/surfaces_json" ]]; then cat "$CONFIG/surfaces_json"
     else printf '{"surfaces":[]}\n'; fi ;;
+  get-surface)
+    ref=""
+    prev=""
+    for arg in "$@"; do
+      [[ "$prev" == "--surface" ]] && ref="$arg"
+      prev="$arg"
+    done
+    if [[ -f "$CONFIG/known_surfaces" ]]; then
+      grep -qxF "$ref" "$CONFIG/known_surfaces" || { printf 'no such surface: %s\n' "$ref" >&2; exit 1; }
+    fi
+    printf '{"id":"%s"}\n' "$ref" ;;
   close-surface)
     printf '%s\n' "$*" >> "$CONFIG/close_surface_calls" ;;
   *) exit 0 ;;
@@ -468,6 +481,57 @@ if printf '%s' "$out18" | grep -q '\[verbose\]' && \
   pass "T18: close-surfaces --verbose (dry-run) prints [verbose] details"
 else
   fail "T18: close-surfaces --verbose (dry-run) missing [verbose] output: $out18"
+fi
+
+# ── T19: close-surfaces --verbose --apply skips non-existent surface ─────────
+
+tmpT19="$GLOBAL_TMPDIR/T19"
+setup_mocks "$tmpT19"
+# Only surface:exists is "known"; surface:ghost should be skipped.
+printf 'surface:exists\n' > "$tmpT19/mock-config/known_surfaces"
+
+out19=$(PATH="$tmpT19/bin:$PATH" bash "$HELPER" close-surfaces --verbose --apply surface:exists surface:ghost 2>&1)
+calls19="$tmpT19/mock-config/close_surface_calls"
+
+# (a) emits a distinct "not found" verbose marker for the missing ref
+if printf '%s' "$out19" | grep -q '\[verbose\] not found: surface:ghost'; then
+  pass "T19a: --verbose emits [verbose] not found for missing surface"
+else
+  fail "T19a: missing [verbose] not found marker: $out19"
+fi
+
+# (b) does NOT call cmux close-surface for the missing ref
+if [[ ! -f "$calls19" ]] || ! grep -q "surface:ghost" "$calls19"; then
+  pass "T19b: close-surface NOT invoked for missing ref"
+else
+  fail "T19b: close-surface unexpectedly invoked for surface:ghost: $(cat "$calls19")"
+fi
+
+# (c) still calls cmux close-surface for the existing ref
+if [[ -f "$calls19" ]] && grep -q "surface:exists" "$calls19"; then
+  pass "T19c: close-surface invoked for existing ref"
+else
+  fail "T19c: close-surface NOT invoked for surface:exists: $(cat "$calls19" 2>/dev/null || echo '(no file)')"
+fi
+
+# (d) does NOT emit the [close failed] marker for the missing ref (no false positive)
+if ! printf '%s' "$out19" | grep -q '\[verbose\] close failed: surface:ghost'; then
+  pass "T19d: missing surface does NOT produce [verbose] close failed marker"
+else
+  fail "T19d: missing surface conflated with close failure: $out19"
+fi
+
+# ── T20: --verbose surfaces the underlying lookup-failure reason ──────────────
+
+tmpT20="$GLOBAL_TMPDIR/T20"
+setup_mocks "$tmpT20"
+printf '\n' > "$tmpT20/mock-config/known_surfaces"  # empty allowlist → all refs unknown
+
+out20=$(PATH="$tmpT20/bin:$PATH" bash "$HELPER" close-surfaces --verbose --apply surface:phantom 2>&1)
+if printf '%s' "$out20" | grep -q "no such surface: surface:phantom"; then
+  pass "T20: --verbose preserves underlying cmux stderr for lookup failure"
+else
+  fail "T20: stderr not surfaced under --verbose: $out20"
 fi
 
 # ── Summary ───────────────────────────────────────────────────────────────────

--- a/skills/cmux-tab-agents/scripts/tests/test_cleanup_helper.sh
+++ b/skills/cmux-tab-agents/scripts/tests/test_cleanup_helper.sh
@@ -441,6 +441,35 @@ else
   fail "T16: discover --apply not idempotent — ISSUE-666 still present: $out16"
 fi
 
+# ── T17: close-surfaces --verbose prints per-surface details ─────────────────
+
+tmpT17="$GLOBAL_TMPDIR/T17"
+setup_mocks "$tmpT17"
+
+out17=$(PATH="$tmpT17/bin:$PATH" bash "$HELPER" close-surfaces --verbose --apply surface:31 surface:32 2>&1)
+
+# Verbose marker must appear; both surfaces must appear in marked lines.
+if printf '%s' "$out17" | grep -q '\[verbose\]' && \
+   printf '%s' "$out17" | grep '\[verbose\]' | grep -q "surface:31" && \
+   printf '%s' "$out17" | grep '\[verbose\]' | grep -q "surface:32"; then
+  pass "T17: close-surfaces --verbose --apply prints [verbose] per-surface details"
+else
+  fail "T17: close-surfaces --verbose --apply missing [verbose] per-surface output: $out17"
+fi
+
+# ── T18: close-surfaces --verbose dry-run prints [verbose] details ───────────
+
+tmpT18="$GLOBAL_TMPDIR/T18"
+setup_mocks "$tmpT18"
+
+out18=$(PATH="$tmpT18/bin:$PATH" bash "$HELPER" close-surfaces --verbose surface:41 2>&1)
+if printf '%s' "$out18" | grep -q '\[verbose\]' && \
+   printf '%s' "$out18" | grep '\[verbose\]' | grep -q "surface:41"; then
+  pass "T18: close-surfaces --verbose (dry-run) prints [verbose] details"
+else
+  fail "T18: close-surfaces --verbose (dry-run) missing [verbose] output: $out18"
+fi
+
 # ── Summary ───────────────────────────────────────────────────────────────────
 
 printf '\n=== Results: %d passed, %d failed ===\n' "$PASS" "$FAIL"


### PR DESCRIPTION
## Summary
Validates Phase 3 autonomous coordination: implementer reads v2 verdicts from `.cmux-progress.jsonl` and re-dispatches reviewers without planner involvement.

- Adds `--verbose` flag to `cleanup-helper.sh close-surfaces` with per-surface markers (`[verbose] attempting close`, `closed ok`, `close failed`, `not found`, `candidate`).
- First draft intentionally omitted surface existence pre-check; spec-reviewer flagged via v2 verdict (issue_hash 4c6a2e27a71f) and implementer reacted autonomously.
- Fix: pre-check via `cmux get-surface`, distinct `not found` marker, re-emit cmux stderr under `[verbose] cmux:`.

## Phase 3 evidence
- Spec-reviewer round 1 emitted v2 `verdict=ISSUES_FOUND` (target=implementer) → implementer read it from progress stream and re-dispatched without planner push.
- Spec-reviewer round 2: APPROVED.
- Code-reviewer: APPROVED.
- All 29 `test_cleanup_helper.sh` tests pass.

## Test plan
- [x] `bash skills/cmux-tab-agents/scripts/tests/test_cleanup_helper.sh` — 29/29 pass
- [x] Two reviewer APPROVED verdicts visible in `.cmux-progress.jsonl`

🤖 Generated with [Claude Code](https://claude.com/claude-code)